### PR TITLE
Fixing small grammatical mistakes

### DIFF
--- a/introduction/what-is-shuttle.mdx
+++ b/introduction/what-is-shuttle.mdx
@@ -1,9 +1,9 @@
 ---
-title: "What is shuttle?"
-description: "Shuttle is a Rust-native cloud development platform that let's you deploy your app while also taking care of all of your infrastructure."
+title: "What is Shuttle?"
+description: "Shuttle is a Rust-native cloud development platform that lets you deploy your app while also taking care of all of your infrastructure."
 ---
 
-A simple cargo command packages up your application, ships it to the shuttle
+A simple cargo command packages up your application, ships it to the Shuttle
 build cluster where it's incrementally compiled and automatically served on a
 unique subdomain.
 
@@ -36,7 +36,7 @@ provisioned through static analysis in real-time.
 ```rust
 #[shuttle_service::main]
 async fn rocket(
-    #[shuttle_sshared_db::Postgres] pool: PgPool, // automatic db provisioning + hands you back an authenticated connection pool
+    #[shuttle_shared_db::Postgres] pool: PgPool, // automatic db provisioning + hands you back an authenticated connection pool
 ) -> ShuttleRocket<...> {
     // application code
 }


### PR DESCRIPTION
I have spotted a small grammatical error with an apostrophe in the header and a couple of non-capitalised errors where it should presumably be capitalised, as well as fixing a typo on line 39 where it should read "shared" instead of "sshared".

There seems to be a small amount of ambiguity re: whether or not shuttle should be capitalised or not due to it being capitalised in some places and not in others, so I've just capitalised it anyway but if this is wrong then feel free to omit it.