### PR TITLE
ci: implement workflow to automatically replicate CONTRIBUTING.md

### DIFF
--- a/.github/workflows/replicate.yml
+++ b/.github/workflows/replicate.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Convert CONTRIBUTING.md title to frontmatter 
         run: |
           sed -i -e '1i ---' \
-          -e '1s/#/title:/'\
-          -e '2i ---' $f;
+          -e '1s/#/title:/' \
+          -e '2i ---' shuttle/CONTRIBUTING.md;
 
       - name: Copy CONTRIBUTING.md to community/contribute.mdx
         run: cp -a shuttle/CONTRIBUTING.md community/contribute.mdx

--- a/.github/workflows/replicate.yml
+++ b/.github/workflows/replicate.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           sed -i -e '1i ---' \
           -e '1s/#/title:/' \
+          -e '2i description:\ "This document describes the best way to get started with contributing to shuttle"' \
           -e '2i ---' shuttle/CONTRIBUTING.md;
 
       - name: Copy CONTRIBUTING.md to community/contribute.mdx

--- a/.github/workflows/replicate.yml
+++ b/.github/workflows/replicate.yml
@@ -1,0 +1,53 @@
+name: contrib
+on:
+  schedule:
+    # run 15:35UTC daily
+    - cron: '35 15 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write # to update contribute.mdx
+  pull-requests: write # to send the update contribute.mdx PRs
+
+jobs:
+  update-contribute:
+    name: Update contribute
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout shuttle repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: shuttle-hq/shuttle
+          path: shuttle
+
+      - name: Convert CONTRIBUTING.md title to frontmatter 
+        run: |
+          sed -i -e '1i ---' \
+          -e '1s/#/title:/'\
+          -e '2i ---' $f;
+
+      - name: Copy CONTRIBUTING.md to community/contribute.mdx
+        run: cp -a shuttle/CONTRIBUTING.md community/contribute.mdx
+
+      - uses: gr2m/create-or-update-pull-request-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          author: github-actions <github-actions@github.com>
+          branch: actions/update-contribute
+          title: 'docs: update contribute doc'
+          body: >
+            The contribute.mdx doc is likely out of date. This is an automatically 
+            generated PR by the `replicate.yml` GitHub workflow, which clones the doc
+            from the main repo, implements the changes here then submits a new PR or 
+            updates an existing PR.
+          commit-message: 'docs: update contribute doc'
+          path: community/contribute.mdx
+

--- a/community/contribute.mdx
+++ b/community/contribute.mdx
@@ -1,7 +1,6 @@
 ---
-title: "Contribute"
-description:
-    "This document describes the best way to get started with contributing to shuttle"
+title: Contributing
+description: "This document describes the best way to get started with contributing to shuttle"
 ---
 
 ## Raise an Issue
@@ -16,6 +15,11 @@ are always appreciated!
 ## Running Locally
 You can use Docker and docker-compose to test shuttle locally during development. See the [Docker install](https://docs.docker.com/get-docker/)
 and [docker-compose install](https://docs.docker.com/compose/install/) instructions if you do not have them installed already.
+
+```bash
+git clone git@github.com:shuttle-hq/shuttle.git
+cd shuttle
+```
 
 You should now be ready to setup a local environment to test code changes to core `shuttle` packages as follows:
 
@@ -48,6 +52,7 @@ shuttle-aws-rds = { path = "[base]/shuttle/resources/aws-rds" }
 shuttle-persist = { path = "[base]/shuttle/resources/persist" }
 shuttle-shared-db = { path = "[base]/shuttle/resources/shared-db" }
 shuttle-secrets = { path = "[base]/shuttle/resources/secrets" }
+shuttle-static-folder = { path = "[base]/shuttle/resources/static-folder" }
 ```
 
 Prime gateway database with an admin user:
@@ -65,6 +70,8 @@ cargo run --bin cargo-shuttle -- login --api-key "test-key"
 cd into one of the examples:
 
 ```bash
+git submodule init
+git submodule update
 cd examples/rocket/hello-world/
 ```
 
@@ -105,17 +112,17 @@ cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- logs
 The steps outlined above starts all the services used by shuttle locally (ie. both `gateway` and `deployer`). However, sometimes you will want to quickly test changes to `deployer` only. To do this replace `make up` with the following:
 
 ```bash
-docker-compose -f docker-compose.rendered.yml up provisioner
+docker compose -f docker-compose.rendered.yml up provisioner
 ```
 
 This prevents `gateway` from starting up. Now you can start deployer only using:
 
 ```bash
 provisioner_address=$(docker inspect --format '{{(index .NetworkSettings.Networks "shuttle_default").IPAddress}}' shuttle_prod_hello-world-rocket-app_run)
-cargo run -p shuttle-deployer -- --provisioner-address $provisioner_address --provisioner-port 8000 --proxy-fqdn local.rs --admin-secret test-key
+cargo run -p shuttle-deployer -- --provisioner-address $provisioner_address --provisioner-port 8000 --proxy-fqdn local.rs --admin-secret test-key --project <project_name>
 ```
 
-The `--admin-secret` can safely be changed to your api-key to make testing easier.
+The `--admin-secret` can safely be changed to your api-key to make testing easier. While `<project_name>` needs to match the name of the project that will be deployed to this deployer. This is the `Cargo.toml` or `Shuttle.toml` name for the project.
 
 ### Using Podman instead of Docker
 If you are using Podman over Docker, then expose a rootless socket of Podman using the following command:
@@ -225,9 +232,11 @@ Lastly, the `user service` is not a folder in this repository, but is the user s
 Currently, if you try to use 'make images' on Windows, you may find that the shell files cannot be read by Bash/WSL. This is due to the fact that Windows may have pulled the files in CRLF format rather than LF[^1], which causes problems with Bash as to run the commands, Linux needs the file in LF format. 
 
 Thankfully, we can fix this problem by simply using the `git config core.autocrlf` command to change how Git handles line endings. It takes a single argument:
-````
+
+```
 git config --global core.autocrlf input
-````
+```
+
 This should allow you to run `make images` and other Make commands with no issues.
 
 If you need to change it back for whatever reason, you can just change the last argument from 'input' to 'true' like so:


### PR DESCRIPTION
This workflow will replicate `CONTRIBUTING.md` from the main repo every day at 15:35 UTC (odd times have lower load). It will use the title from `CONTRIBUTING.md` but convert it to a frontmatter title, and insert a description. If there are any changes between the main repo doc and the docs `community/contribute.md` doc, a PR will be created with the changes. If there are more changes before the PR is merged, they will be pushed to the same PR. 

Ideally we would implement a trigger in the main repo when there are changes to `CONTRIBUTING.md` so we get the PR immediately, but this is still a pretty big improvement in convenience. So I suggest we optimize it with that at a later date.

PS. I also left in the option of manually dispatching, should urgent changes be necessary. 

First PR for reference: https://github.com/oddgrd/shuttle-docs-odd/pull/1