### PR TITLE
fix: small issue with header in markdown

### DIFF
--- a/tutorials/authentication.mdx
+++ b/tutorials/authentication.mdx
@@ -209,9 +209,9 @@ field for identification rather than using something like the `username` field
 because you may add the ability to change usernames, which can leave things
 pointing to the wrong places.
 
-### Registering our database Before our app can use the database we have to add
+### Registering our database
 
-sqlx with some features: `cargo add sqlx -F postgres runtime-tokio-native-tls`.
+Before our app can use the database we have to add sqlx with some features: `cargo add sqlx -F postgres runtime-tokio-native-tls`.
 We will also enable the Postgres feature for shuttle with
 `cargo add shuttle-service -F sqlx-postgres`.
 


### PR DESCRIPTION
The tutorial for the Axum authentication post on the Shuttle docs page has a bit of a typo in the markdown, where the header for the Registering our database portion at line 212 includes parts of the next sentence.

I have split it where I presume that it should be split, which is at the "Before our app" block.