### PR TITLE
Fixed link to static files example on GitHub

### DIFF
--- a/resources/shuttle-static-folder.mdx
+++ b/resources/shuttle-static-folder.mdx
@@ -7,7 +7,7 @@ This plugin allows services to get the path to a static folder at runtime
 ## Usage
 Add `shuttle-static-folder` to the dependencies for your service. This resource can be using by the `shuttle_static_folder::StaticFolder` attribute to get a `PathBuf` with the location of the static folder.
 
-An example using the Axum framework can be found on [GitHub](https://github.com/shuttle-hq/examples/tree/main/axum/websocket)
+An example using the Axum framework can be found on [GitHub](https://github.com/shuttle-hq/examples/tree/main/axum/static-files)
 
 ``` rust
 #[shuttle_service::main]


### PR DESCRIPTION
The link to the GitHub repo in the "static files" example incorrectly linked to the websockets example.  I corrected the link so that it goes to the static files example.