### PR TITLE
docs: make intended Secrets.toml location explicit

### DIFF
--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -11,7 +11,12 @@ To be able to create this example, we'll need to grab an API token from the [Dis
 
 1. Click the New Application button, name your application and click Create.
 2. Navigate to the Bot tab in the lefthand menu, and add a new bot.
-3. On the bot page click the Reset Token button to reveal your token. Put this token in your `Secrets.toml`. It's very important that you don't reveal your token to anyone, as it can be abused. Create a `.gitignore` file to omit your `Secrets.toml` from version control.
+3. On the bot page click the Reset Token button to reveal your token. Put this token in your `Secrets.toml` (explained below). It's very important that you don't reveal your token to anyone, as it can be abused. Create a `.gitignore` file to omit your `Secrets.toml` from version control.
+
+Your `Secrets.toml` file needs to be in the root of your directory once the project's been initialised - the file will use a format similar to a `.env` file, like so:
+```toml Secrets.toml
+DISCORD_TOKEN = 'the contents of my discord token'
+```
 
 To add the bot to a server, we need to create an invite link:
 
@@ -27,6 +32,7 @@ cargo shuttle init --no-framework
 ```
 
 This will simply initialize a new cargo crate with a dependency on `shuttle-service`.
+
 We also want to add several dependencies for this - make sure your Cargo.toml looks like below:
 
 ```toml Cargo.toml

--- a/examples/serenity.mdx
+++ b/examples/serenity.mdx
@@ -100,6 +100,7 @@ And your `Secrets.toml` file should look like this (and have your token inside):
 ```toml Secrets.toml
 DISCORD_TOKEN = 'the contents of my discord token'
 ```
+Note that your `Secrets.toml` file should be in the root of your directory!
 
 Create a project, this will start an isolated deployer container for you under the hood:
 ```bash
@@ -120,6 +121,7 @@ To run this bot we need a valid Discord Token. To get started log in to the [Dis
 1. Click the New Application button, name your application and click Create.
 2. Navigate to the Bot tab in the lefthand menu, and add a new bot.
 3. On the bot page click the Reset Token button to reveal your token. Put this token in your `Secrets.toml`. It's very important that you don't reveal your token to anyone, as it can be abused. Create a `.gitignore` file to omit your `Secrets.toml` from version control.
+
 
 To add the bot to a server we need to create an invite link.
 


### PR DESCRIPTION
See title.

Discord thread ref: https://discord.com/channels/803236282088161321/1077698025155215360

Hopefully this will prevent confusion in the future as to where the `Secrets.toml` file should be - it appears that the examples operated on the assumption that users will know that they're supposed to put the file in the root of the directory because it says so in the docs for the `shuttle-secrets` lib (and partially because it just makes sense to do so), however it doesn't state this explicitly on the examples which may cause some confusion. 