### PR TITLE
Feat/refactor examples to shuttle next

### DIFF
--- a/examples/actix.mdx
+++ b/examples/actix.mdx
@@ -27,8 +27,8 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.3.1"
-shuttle-actix-web = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-actix-web = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
@@ -80,10 +80,10 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.3.1"
-shuttle-actix-web = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-actix-web = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 serde = "1.0.148"
-shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+shuttle-shared-db = { version = "0.12.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.26.0" }
 ```
@@ -209,9 +209,9 @@ futures = "0.3"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-actix-web = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-static-folder = "0.8.0"
+shuttle-actix-web = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-static-folder = "0.12.0"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 tracing = "0.1"
 ```

--- a/examples/actix.mdx
+++ b/examples/actix.mdx
@@ -29,9 +29,9 @@ edition = "2021"
 actix-web = "4.2.1"
 shuttle-service = { version = '0.11.0', features = ["web-actix-web"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use actix_web::{get, web::ServiceConfig};
 use shuttle_service::ShuttleActixWeb;
 
@@ -78,9 +78,9 @@ edition = "2021"
 actix-web = "4.2.1"
 shuttle-service = { version = '0.11.0', features = ["web-actix-web"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use actix_web::middleware::Logger;
 use actix_web::{
     error, get, post,
@@ -189,8 +189,6 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 shuttle-service = { version = "0.11.0", features = ["web-actix-web"] }
 shuttle-static-folder = "0.11.3"
@@ -209,14 +207,14 @@ tracing = "0.1"
 The structure for this example is:
 ```
 -> src
-    -> lib.rs
+    -> main.rs
 -> static
     ->  index.html
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use actix_files::NamedFile;
 use actix_web::{
     web::{self, ServiceConfig},

--- a/examples/actix.mdx
+++ b/examples/actix.mdx
@@ -26,26 +26,30 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-actix-web = "4.2.1"
-shuttle-service = { version = '0.11.0', features = ["web-actix-web"] }
+actix-web = "4.3.1"
+shuttle-actix-web = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
 ```Rust main.rs
 use actix_web::{get, web::ServiceConfig};
-use shuttle_service::ShuttleActixWeb;
+use shuttle_actix_web::ShuttleActixWeb;
 
 #[get("/hello")]
 async fn hello_world() -> &'static str {
     "Hello World!"
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn actix_web(
-) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
-    Ok(move |cfg: &mut ServiceConfig| {
+) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
+    let config = move |cfg: &mut ServiceConfig| {
         cfg.service(hello_world);
-    })
+    };
+
+    Ok(config.into())
 }
 ```
 
@@ -75,8 +79,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-actix-web = "4.2.1"
-shuttle-service = { version = '0.11.0', features = ["web-actix-web"] }
+actix-web = "4.3.1"
+shuttle-actix-web = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+serde = "1.0.148"
+shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -88,7 +97,8 @@ use actix_web::{
     Result,
 };
 use serde::{Deserialize, Serialize};
-use shuttle_service::{error::CustomError, ShuttleActixWeb};
+use shuttle_actix_web::ShuttleActixWeb;
+use shuttle_runtime::{CustomError};
 use sqlx::{Executor, FromRow, PgPool};
 
 #[get("/{id}")]
@@ -118,17 +128,17 @@ struct AppState {
     pool: PgPool,
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn actix_web(
     #[shuttle_shared_db::Postgres] pool: PgPool,
-) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
+) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;
 
     let state = web::Data::new(AppState { pool });
 
-    Ok(move |cfg: &mut ServiceConfig| {
+    let config = move |cfg: &mut ServiceConfig| {
         cfg.service(
             web::scope("/todos")
                 .wrap(Logger::default())
@@ -136,7 +146,9 @@ async fn actix_web(
                 .service(add)
                 .app_data(state),
         );
-    })
+    };
+
+    Ok(config.into())
 }
 
 #[derive(Deserialize)]
@@ -149,7 +161,6 @@ struct Todo {
     pub id: i32,
     pub note: String,
 }
-
 ```
 
 And your `schema.sql` should look like this:
@@ -190,17 +201,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-service = { version = "0.11.0", features = ["web-actix-web"] }
-shuttle-static-folder = "0.11.3"
-actix-web = "4.2.1"
-actix-ws = "0.2.5"
 actix-files = "0.6.2"
+actix-web = "4.3.1"
+actix-ws = "0.2.5"
+chrono = { version = "0.4.23", features = ["serde"] }
 futures = "0.3"
 reqwest = "0.11"
-tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = { version = "0.4.23", features = ["serde"] }
+shuttle-actix-web = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-static-folder = "0.8.0"
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 tracing = "0.1"
 ```
 
@@ -224,7 +236,7 @@ use actix_ws::Message;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use serde::Serialize;
-use shuttle_service::ShuttleActixWeb;
+use shuttle_actix_web::ShuttleActixWeb;
 use std::{
     sync::{atomic::AtomicUsize, Arc},
     time::Duration,
@@ -321,9 +333,9 @@ async fn index() -> impl Responder {
         .map_err(|e| actix_web::error::ErrorInternalServerError(e))
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn actix_web(
-) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
+) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
     // We're going to use channels to communicate between threads.
     // api state channel
     let (tx_api_state, rx_api_state) = watch::channel(ApiStateMessage::default());
@@ -396,21 +408,21 @@ async fn actix_web(
 
     let app_state = web::Data::new((tx_ws_state, rx_api_state));
 
-    Ok(move |cfg: &mut ServiceConfig| {
+    let config = move |cfg: &mut ServiceConfig| {
         cfg.service(web::resource("/").route(web::get().to(index)))
             .service(
                 web::resource("/ws")
                     .app_data(app_state)
                     .route(web::get().to(websocket)),
             );
-    })
+    };
+    Ok(config.into())
 }
 
 async fn get_api_status(client: &reqwest::Client) -> bool {
     let response = client.get(STATUS_URI).send().await;
     response.is_ok()
 }
-
 ```
 
 Your `index.html` should look like this:

--- a/examples/axum.mdx
+++ b/examples/axum.mdx
@@ -25,8 +25,8 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.10"
-shuttle-axum = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-axum = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
@@ -82,9 +82,9 @@ hyper = { version = "0.14.23", features = ["client", "http2"] }
 hyper-tls = "0.5.0"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
-shuttle-axum = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-static-folder = "0.8.0"
+shuttle-axum = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-static-folder = "0.12.0"
 tokio = { version = "1.26.0", features = ["full"] }
 tower-http = { version = "0.3.0", features = ["fs"] }
 ```

--- a/examples/axum.mdx
+++ b/examples/axum.mdx
@@ -26,13 +26,11 @@ edition = "2021"
 [dependencies]
 axum = "0.5"
 shuttle-service = { version = "0.11.0", features = ["web-axum"] }
-sync_wrapper = "0.1"
 ```
 Your `main.rs` should look like this:
 
 ```Rust main.rs
 use axum::{routing::get, Router};
-use sync_wrapper::SyncWrapper;
 
 async fn hello_world() -> &'static str {
     "Hello, world!"
@@ -41,9 +39,8 @@ async fn hello_world() -> &'static str {
 #[shuttle_service::main]
 async fn axum() -> shuttle_service::ShuttleAxum {
     let router = Router::new().route("/hello", get(hello_world));
-    let sync_wrapper = SyncWrapper::new(router);
 
-    Ok(sync_wrapper)
+    Ok(router)
 }
 ```
 
@@ -84,7 +81,6 @@ hyper-tls = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shuttle-service = { version = "0.11.0", features = ["web-axum"] }
-sync_wrapper = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
 Your `main.rs` should look like this:
@@ -108,7 +104,6 @@ use hyper::{Client, Uri};
 use hyper_tls::HttpsConnector;
 use serde::Serialize;
 use shuttle_service::ShuttleAxum;
-use sync_wrapper::SyncWrapper;
 use tokio::{
     sync::{watch, Mutex},
     time::sleep,
@@ -170,9 +165,7 @@ async fn main() -> ShuttleAxum {
         .route("/websocket", get(websocket_handler))
         .layer(Extension(state));
 
-    let sync_wrapper = SyncWrapper::new(router);
-
-    Ok(sync_wrapper)
+    Ok(router)
 }
 
 async fn websocket_handler(

--- a/examples/axum.mdx
+++ b/examples/axum.mdx
@@ -24,8 +24,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.5"
-shuttle-service = { version = "0.11.0", features = ["web-axum"] }
+axum = "0.6.10"
+shuttle-axum = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -36,11 +38,11 @@ async fn hello_world() -> &'static str {
     "Hello, world!"
 }
 
-#[shuttle_service::main]
-async fn axum() -> shuttle_service::ShuttleAxum {
+#[shuttle_runtime::main]
+async fn axum() -> shuttle_axum::ShuttleAxum {
     let router = Router::new().route("/hello", get(hello_world));
 
-    Ok(router)
+    Ok(router.into())
 }
 ```
 
@@ -73,29 +75,33 @@ edition = "2021"
 
 
 [dependencies]
-axum = { version = "0.5", features = ["ws"] }
-chrono = { version = "0.4", features = ["serde"] }
-futures = "0.3"
-hyper = { version = "0.14", features = ["client", "http2"] }
-hyper-tls = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-shuttle-service = { version = "0.11.0", features = ["web-axum"] }
-tokio = { version = "1", features = ["full"] }
+axum = { version = "0.6.10", features = ["ws"] }
+chrono = { version = "0.4.23", features = ["serde"] }
+futures = "0.3.25"
+hyper = { version = "0.14.23", features = ["client", "http2"] }
+hyper-tls = "0.5.0"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
+shuttle-axum = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-static-folder = "0.8.0"
+tokio = { version = "1.26.0", features = ["full"] }
+tower-http = { version = "0.3.0", features = ["fs"] }
 ```
 Your `main.rs` should look like this:
 
 ```rust main.rs
 // main.rs
-use std::{sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use axum::{
     extract::{
         ws::{Message, WebSocket},
         WebSocketUpgrade,
     },
-    response::{Html, IntoResponse},
-    routing::get,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, get_service},
     Extension, Router,
 };
 use chrono::{DateTime, Utc};
@@ -103,11 +109,12 @@ use futures::{SinkExt, StreamExt};
 use hyper::{Client, Uri};
 use hyper_tls::HttpsConnector;
 use serde::Serialize;
-use shuttle_service::ShuttleAxum;
+use shuttle_axum::ShuttleAxum;
 use tokio::{
     sync::{watch, Mutex},
     time::sleep,
 };
+use tower_http::services::ServeDir;
 
 struct State {
     clients_count: usize,
@@ -115,17 +122,18 @@ struct State {
 }
 
 const PAUSE_SECS: u64 = 15;
-const STATUS_URI: &str = "https://api.shuttle.rs/status";
+const STATUS_URI: &str = "https://api.shuttle.rs";
 
 #[derive(Serialize)]
 struct Response {
     clients_count: usize,
-    datetime: DateTime<Utc>,
+    #[serde(rename = "dateTime")]
+    date_time: DateTime<Utc>,
     is_up: bool,
 }
 
-#[shuttle_service::main]
-async fn main() -> ShuttleAxum {
+#[shuttle_runtime::main]
+async fn axum(#[shuttle_static_folder::StaticFolder] static_folder: PathBuf) -> ShuttleAxum {
     let (tx, rx) = watch::channel(Message::Text("{}".to_string()));
 
     let state = Arc::new(Mutex::new(State {
@@ -147,7 +155,7 @@ async fn main() -> ShuttleAxum {
 
             let response = Response {
                 clients_count: state_send.lock().await.clients_count,
-                datetime: Utc::now(),
+                date_time: Utc::now(),
                 is_up,
             };
             let msg = serde_json::to_string(&response).unwrap();
@@ -160,12 +168,18 @@ async fn main() -> ShuttleAxum {
         }
     });
 
+    let serve_dir = get_service(ServeDir::new(static_folder)).handle_error(handle_error);
+
     let router = Router::new()
-        .route("/", get(index))
         .route("/websocket", get(websocket_handler))
+        .fallback_service(serve_dir)
         .layer(Extension(state));
 
-    Ok(router)
+    Ok(router.into())
+}
+
+async fn handle_error(_err: std::io::Error) -> impl IntoResponse {
+    (StatusCode::INTERNAL_SERVER_ERROR, "Something went wrong...")
 }
 
 async fn websocket_handler(
@@ -212,10 +226,6 @@ async fn websocket(stream: WebSocket, state: Arc<Mutex<State>>) {
     // This client disconnected
     state.lock().await.clients_count -= 1;
 }
-
-async fn index() -> Html<&'static str> {
-    Html(include_str!("../index.html"))
-}
 ```
 
 And your `index.html` should look like this:
@@ -224,78 +234,107 @@ And your `index.html` should look like this:
 <!-- index.html -->
 <!DOCTYPE html>
 <html lang="en" class="bg-gray-600">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Websocket status page</title>
-        <script src="https://cdn.tailwindcss.com"></script>
-    </head>
-    <body class="flex justify-around items-center h-screen w-screen m-0 text-center">
-        <div class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md">
-            <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
-                Current API status
-            </div>
-            <div id="is_ok" class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold uppercase"></div>
-        </div>
-        <div class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md">
-            <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
-                Last check time
-            </div>
-            <div id="datetime" class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold"> </div>
-        </div>
-        <div class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md">
-            <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
-                Clients watching
-            </div>
-            <div id="clients_count" class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold"></div>
-        </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Websocket status page</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body
+    class="flex justify-around items-center h-screen w-screen m-0 text-center"
+  >
+    <div
+      class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md"
+    >
+      <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
+        Current API status
+      </div>
+      <div
+        id="is_ok"
+        class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold uppercase"
+      ></div>
+    </div>
+    <div
+      class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md"
+    >
+      <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
+        Last check time
+      </div>
+      <div
+        id="dateTime"
+        class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold"
+      ></div>
+    </div>
+    <div
+      class="flex max-w-sm flex-col overflow-hidden rounded-lg transition blur-md"
+    >
+      <div class="flex-shrink-0 bg-gray-800 text-slate-50 p-5">
+        Clients watching
+      </div>
+      <div
+        id="clients_count"
+        class="flex flex-1 flex-col justify-between p-6 bg-gray-500 text-xl font-bold"
+      ></div>
+    </div>
 
-        <button id="open" class="absolute text-2xl bg-gray-800 text-slate-50 p-2 rounded shadow-lg shadow-slate-800 hover:shadow-md scale-105 hover:scale-100 transition">Open connection</button>
+    <button
+      id="open"
+      class="absolute text-2xl bg-gray-800 text-slate-50 p-2 rounded shadow-lg shadow-slate-800 hover:shadow-md scale-105 hover:scale-100 transition"
+    >
+      Open connection
+    </button>
 
-        <script type="text/javascript">
-         const is_ok = document.querySelector("#is_ok");
-         const datetime = document.querySelector("#datetime");
-         const clients_count = document.querySelector("#clients_count");
-         const button = document.querySelector("button");
+    <script type="text/javascript">
+      const is_ok = document.querySelector('#is_ok');
+      const dateTime = document.querySelector('#dateTime');
+      const clients_count = document.querySelector('#clients_count');
+      const button = document.querySelector('button');
 
-         function track() {
-             const websocket = new WebSocket(`wss://${window.location.host}/websocket`);
+      function track() {
+        const proto = location.protocol.startsWith('https') ? 'wss' : 'ws';
+        const websocket = new WebSocket(
+          `${proto}://${window.location.host}/websocket`,
+        );
 
-             websocket.onopen = () => {
-                 console.log("connection opened");
-                 document.querySelectorAll("body > div").forEach(e => e.classList.remove("blur-md"));
-                 document.querySelector("body > button").classList.add("hidden");
-             }
+        websocket.onopen = () => {
+          console.log('connection opened');
+          document
+            .querySelectorAll('body > div')
+            .forEach((e) => e.classList.remove('blur-md'));
+          document.querySelector('body > button').classList.add('hidden');
+        };
 
-             websocket.onclose = () => {
-                 console.log("connection closed");
-                 document.querySelectorAll("body > div").forEach(e => e.classList.add("blur-md"));
-                 document.querySelector("body > button").classList.remove("hidden");
-             }
+        websocket.onclose = () => {
+          console.log('connection closed');
+          document
+            .querySelectorAll('body > div')
+            .forEach((e) => e.classList.add('blur-md'));
+          document.querySelector('body > button').classList.remove('hidden');
+        };
 
-             websocket.onmessage = (e) => {
-                 const response = JSON.parse(e.data);
+        websocket.onmessage = (e) => {
+          const response = JSON.parse(e.data);
 
-                 if (response.is_up) {
-                     is_ok.textContent = "up";
-                     is_ok.classList.add("text-green-600");
-                     is_ok.classList.remove("text-rose-700");
-                 } else {
-                     is_ok.textContent = "down";
-                     is_ok.classList.add("text-rose-700");
-                     is_ok.classList.remove("text-green-600");
-                 }
+          if (response.is_up) {
+            is_ok.textContent = 'up';
+            is_ok.classList.add('text-green-600');
+            is_ok.classList.remove('text-rose-700');
+          } else {
+            is_ok.textContent = 'down';
+            is_ok.classList.add('text-rose-700');
+            is_ok.classList.remove('text-green-600');
+          }
 
-                 datetime.textContent = new Date(response.datetime).toLocaleString();
-                 clients_count.textContent = response.clients_count;
-             }
-         }
+          dateTime.textContent = new Date(response.dateTime).toLocaleString();
+          clients_count.textContent = response.clients_count;
+        };
+      }
 
-         track();
-         button.addEventListener("click", track);
-        </script>
-    </body>
+      track();
+      button.addEventListener('click', track);
+    </script>
+  </body>
 </html>
 ```
 

--- a/examples/axum.mdx
+++ b/examples/axum.mdx
@@ -23,16 +23,14 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 axum = "0.5"
 shuttle-service = { version = "0.11.0", features = ["web-axum"] }
 sync_wrapper = "0.1"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use axum::{routing::get, Router};
 use sync_wrapper::SyncWrapper;
 
@@ -76,7 +74,6 @@ name = "websocket"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 
 [dependencies]
 axum = { version = "0.5", features = ["ws"] }
@@ -90,10 +87,10 @@ shuttle-service = { version = "0.11.0", features = ["web-axum"] }
 sync_wrapper = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```rust lib.rs
-// lib.rs
+```rust main.rs
+// main.rs
 use std::{sync::Arc, time::Duration};
 
 use axum::{

--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -74,7 +74,7 @@ binding to a socket, like so:
 #[shuttle_service::async_trait]
 impl shuttle_service::Service for CustomService {
     async fn bind(
-        mut self: Box<Self>,
+        mut self,
         addr: std::net::SocketAddr,
     ) -> Result<(), shuttle_service::error::Error> {
         

--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -49,7 +49,6 @@ poise = "0.5.2"
 serde = "1.0"
 shuttle-secrets = "0.11.0"
 shuttle-service = { version = "0.11.0"}
-sync_wrapper = "0.1.2"
 tokio = "1.22.0"
 ```
 
@@ -62,7 +61,7 @@ pub struct CustomService {
     discord_bot:
         FrameworkBuilder<Data, Box<(dyn std::error::Error +
          std::marker::Send + Sync + 'static)>>,
-    router: SyncWrapper<Router>,
+    router: Router,
 }
 ```
 
@@ -151,7 +150,7 @@ pub struct CustomService {
     discord_bot:
         FrameworkBuilder<Data, Box<(dyn std::error::Error +
          std::marker::Send + Sync + 'static)>>,
-    router: SyncWrapper<Router>,
+    router: Router,
 }
 
 #[shuttle_service::main]
@@ -177,7 +176,6 @@ async fn init(
         });
 
     let router = build_router();
-    let router = SyncWrapper::new(router);
 
     Ok(CustomService {
         discord_bot,

--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -41,8 +41,6 @@ name = "custom-service"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 anyhow = "1.0.62"
 axum = "0.6.4"
@@ -59,7 +57,7 @@ tokio = "1.22.0"
 To get started, we need to return a wrapper struct from our `shuttle_service::main` function that 
 implements `shuttle_service::Service`, which we can declare like so:
 
-```rust lib.rs
+```rust main.rs
 pub struct CustomService {
     discord_bot:
         FrameworkBuilder<Data, Box<(dyn std::error::Error +
@@ -73,7 +71,7 @@ for example if you're implementing service for an HTTP server, you can use the `
 You can only have one HTTP service bound to the `addr`, but you can start other services that don't rely on 
 binding to a socket, like so:
 
-```rust lib.rs
+```rust main.rs
 #[shuttle_service::async_trait]
 impl shuttle_service::Service for CustomService {
     async fn bind(
@@ -101,7 +99,7 @@ Before we can actually run the program, we will need to set up the commands and 
 ```rust commands.rs
 use poise::serenity_prelude as serenity;
 
-// this is a blank struct initialised in lib.rs and then imported here
+// this is a blank struct initialised in main.rs and then imported here
 use crate::Data;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -137,7 +135,7 @@ pub async fn hello_world() -> impl IntoResponse {
 To finish up, we return the wrapper struct from our `shuttle_service::main` function and add implementation
 for setting up each of our services for the struct, like so:
 
-```rust lib.rs
+```rust main.rs
 use poise::serenity_prelude as serenity;
 use shuttle_secrets::SecretStore;
 use std::sync::Arc;

--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -47,9 +47,9 @@ axum = "0.6.4"
 hyper = "0.14.24"
 poise = "0.5.2"
 serde = "1.0"
-shuttle-secrets = "0.11.0"
-shuttle-service = { version = "0.11.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-secrets = "0.12.0"
+shuttle-service = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = "1.26.0"
 ```
 

--- a/examples/custom-service.mdx
+++ b/examples/custom-service.mdx
@@ -48,12 +48,13 @@ hyper = "0.14.24"
 poise = "0.5.2"
 serde = "1.0"
 shuttle-secrets = "0.11.0"
-shuttle-service = { version = "0.11.0"}
-tokio = "1.22.0"
+shuttle-service = { version = "0.11.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = "1.26.0"
 ```
 
 ### Getting Started
-To get started, we need to return a wrapper struct from our `shuttle_service::main` function that 
+To get started, we need to return a wrapper struct from our `shuttle_runtime::main` function that 
 implements `shuttle_service::Service`, which we can declare like so:
 
 ```rust main.rs
@@ -131,7 +132,7 @@ pub async fn hello_world() -> impl IntoResponse {
 ```
 
 ### Struct Implementation
-To finish up, we return the wrapper struct from our `shuttle_service::main` function and add implementation
+To finish up, we return the wrapper struct from our `shuttle_runtime::main` function and add implementation
 for setting up each of our services for the struct, like so:
 
 ```rust main.rs
@@ -153,7 +154,7 @@ pub struct CustomService {
     router: Router,
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn init(
     #[shuttle_secrets::Secrets] secrets: SecretStore,
 ) -> Result<CustomService, shuttle_service::Error> {

--- a/examples/poem.mdx
+++ b/examples/poem.mdx
@@ -24,24 +24,27 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-poem = "1.3.35"
-shuttle-service = { version = "0.11.0", features = ["web-poem"] }
+poem = "1.3.55"
+shuttle-poem = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
 ```Rust main.rs
 use poem::{get, handler, Route};
+use shuttle_poem::ShuttlePoem;
 
 #[handler]
 fn hello_world() -> &'static str {
     "Hello, world!"
 }
 
-#[shuttle_service::main]
-async fn main() -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+#[shuttle_runtime::main]
+async fn poem() -> ShuttlePoem<impl poem::Endpoint> {
     let app = Route::new().at("/hello", get(hello_world));
 
-    Ok(app)
+    Ok(app.into())
 }
 ```
 Create a project, this will start an isolated deployer container for you under the hood:
@@ -74,12 +77,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mongodb = "2.3.0"
-poem = "1.3.35"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-shuttle-service = { version = "0.11.0", features = ["web-poem"] }
-shuttle-shared-db = { version = "0.11.0", features = ["mongodb"] }
+mongodb = "2.4.0"
+poem = "1.3.55"
+shuttle-poem = { version = "0.1.0" }
+shuttle-shared-db = { version = "0.8.0", features = ["mongodb"] }
+shuttle-runtime = { version = "0.1.0" }
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
+tokio = { version = "1.26.0" }
 ```
 
 Your `main.rs` should look like this:
@@ -97,6 +102,7 @@ use poem::{
     EndpointExt, FromRequest, Request, RequestBody, Result, Route,
 };
 use serde::{Deserialize, Serialize};
+use shuttle_poem::ShuttlePoem;
 
 struct ObjectIdGuard(ObjectId);
 
@@ -140,10 +146,10 @@ async fn add(Json(todo): Json<Todo>, collection: Data<&Collection<Todo>>) -> Res
         .to_string())
 }
 
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn poem(
     #[shuttle_shared_db::MongoDb] db: Database,
-) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+) -> ShuttlePoem<impl poem::Endpoint> {
     let collection = db.collection::<Todo>("todos");
 
     let app = Route::new()
@@ -151,7 +157,7 @@ async fn main(
         .at("/todo/:id", get(retrieve))
         .with(AddData::new(collection));
 
-    Ok(app)
+    Ok(app.into())
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -190,11 +196,13 @@ edition = "2021"
 
 
 [dependencies]
-poem = "1.3.35"
-serde = "1.0"
-shuttle-service = { version = "0.11.0", features = ["web-poem"] }
-shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+poem = "1.3.55"
+serde = "1.0.148"
+shuttle-poem = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tokio = { version = "1.26.0" }
 ```
 
 Your `main.rs` should look like this:
@@ -209,7 +217,8 @@ use poem::{
     EndpointExt, Result, Route,
 };
 use serde::{Deserialize, Serialize};
-use shuttle_service::error::CustomError;
+use shuttle_runtime::CustomError;
+use shuttle_poem::ShuttlePoem;
 use sqlx::{Executor, FromRow, PgPool};
 
 #[handler]
@@ -234,10 +243,10 @@ async fn add(Json(data): Json<TodoNew>, state: Data<&PgPool>) -> Result<Json<Tod
     Ok(Json(todo))
 }
 
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn poem(
     #[shuttle_shared_db::Postgres] pool: PgPool,
-) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+) -> ShuttlePoem<impl poem::Endpoint> {
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;
@@ -247,7 +256,7 @@ async fn main(
         .at("/todo/:id", get(retrieve))
         .with(AddData::new(pool));
 
-    Ok(app)
+    Ok(app.into())
 }
 
 #[derive(Deserialize)]

--- a/examples/poem.mdx
+++ b/examples/poem.mdx
@@ -23,15 +23,13 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 poem = "1.3.35"
 shuttle-service = { version = "0.11.0", features = ["web-poem"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use poem::{get, handler, Route};
 
 #[handler]
@@ -84,9 +82,9 @@ shuttle-service = { version = "0.11.0", features = ["web-poem"] }
 shuttle-shared-db = { version = "0.11.0", features = ["mongodb"] }
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use mongodb::bson::doc;
 use mongodb::bson::oid::ObjectId;
 use mongodb::{Collection, Database};
@@ -190,7 +188,6 @@ name = "postgres"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 
 [dependencies]
 poem = "1.3.35"
@@ -200,9 +197,9 @@ shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
 sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use poem::{
     error::BadRequest,
     get, handler,

--- a/examples/poem.mdx
+++ b/examples/poem.mdx
@@ -25,8 +25,8 @@ edition = "2021"
 
 [dependencies]
 poem = "1.3.55"
-shuttle-poem = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-poem = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
@@ -79,9 +79,9 @@ edition = "2021"
 [dependencies]
 mongodb = "2.4.0"
 poem = "1.3.55"
-shuttle-poem = { version = "0.1.0" }
-shuttle-shared-db = { version = "0.8.0", features = ["mongodb"] }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-poem = { version = "0.12.0" }
+shuttle-shared-db = { version = "0.12.0", features = ["mongodb"] }
+shuttle-runtime = { version = "0.12.0" }
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.26.0" }
@@ -198,9 +198,9 @@ edition = "2021"
 [dependencies]
 poem = "1.3.55"
 serde = "1.0.148"
-shuttle-poem = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+shuttle-poem = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-shared-db = { version = "0.12.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.26.0" }
 ```

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -25,8 +25,8 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0-rc.2"
-shuttle-rocket = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-rocket = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
@@ -88,8 +88,8 @@ jsonwebtoken = { version = "8.1.1", default-features = false }
 lazy_static = "1.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-rocket = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-rocket = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
@@ -384,10 +384,10 @@ edition = "2021"
 [dependencies]
 nanoid = "0.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-shuttle-rocket = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-rocket = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 serde = "1.0.148"
-shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+shuttle-shared-db = { version = "0.12.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.26.0" }
 url = "2.3.1"

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -23,15 +23,13 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 rocket = "0.5.0-rc.2"
 shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 #[macro_use]
 extern crate rocket;
 
@@ -81,7 +79,6 @@ name = "authentication"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 
 [dependencies]
 chrono = "0.4"
@@ -91,10 +88,10 @@ rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
-// lib.rs
+```Rust main.rs
+// main.rs
 use rocket::http::Status;
 use rocket::response::status::Custom;
 use rocket::serde::json::Json;
@@ -371,7 +368,7 @@ The project consists of the following files
 
 - `Shuttle.toml` contains the name of the app (if name is `myapp` domain will be `myapp.shuttleapp.rs`)
 - `migrations` folder is for DB migration files created by [sqlx-cli](https://github.com/launchbadge/sqlx/tree/master/sqlx-cli)
-- `src/lib.rs` is where all the magic happens - it creates a shuttle service with two endpoints: one for creating new short URLs and one for handling shortened URLs.
+- `src/main.rs` is where all the magic happens - it creates a shuttle service with two endpoints: one for creating new short URLs and one for handling shortened URLs.
 
 ```toml Cargo.toml
 [package]
@@ -379,7 +376,6 @@ name = "url-shortener"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 
 [dependencies]
 nanoid = "0.4"
@@ -390,10 +386,10 @@ shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
 sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
 url = "2.2"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
-// lib.rs
+```Rust main.rs
+// main.rs
 #[macro_use]
 extern crate rocket;
 

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -25,7 +25,9 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0-rc.2"
-shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
+shuttle-rocket = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -38,11 +40,11 @@ fn index() -> &'static str {
     "Hello, world!"
 }
 
-#[shuttle_service::main]
-async fn rocket() -> shuttle_service::ShuttleRocket {
+#[shuttle_runtime::main]
+async fn rocket() -> shuttle_rocket::ShuttleRocket {
     let rocket = rocket::build().mount("/hello", routes![index]);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 
@@ -81,12 +83,14 @@ edition = "2021"
 
 
 [dependencies]
-chrono = "0.4"
-jsonwebtoken = { version = "8", default-features = false }
-lazy_static = "1.4"
+chrono = "0.4.23"
+jsonwebtoken = { version = "8.1.1", default-features = false }
+lazy_static = "1.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
-shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
+serde = { version = "1.0.148", features = ["derive"] }
+shuttle-rocket = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -163,11 +167,11 @@ fn login(login: Json<LoginRequest>) -> Result<Json<LoginResponse>, Custom<String
     Ok(Json(response))
 }
 
-#[shuttle_service::main]
-async fn rocket() -> shuttle_service::ShuttleRocket {
+#[shuttle_runtime::main]
+async fn rocket() -> shuttle_rocket::ShuttleRocket {
     let rocket = rocket::build().mount("/", routes![public, private, login]);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 Your `claims.rs` should look like this:
@@ -378,13 +382,15 @@ edition = "2021"
 
 
 [dependencies]
-nanoid = "0.4"
+nanoid = "0.4.0"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-serde = "1.0"
-shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
-shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
-url = "2.2"
+shuttle-rocket = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+serde = "1.0.148"
+shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tokio = { version = "1.26.0" }
+url = "2.3.1"
 ```
 Your `main.rs` should look like this:
 
@@ -399,7 +405,7 @@ use rocket::{
     routes, State,
 };
 use serde::Serialize;
-use shuttle_service::{error::CustomError, ShuttleRocket};
+use shuttle_runtime::CustomError;
 use sqlx::migrate::Migrator;
 use sqlx::{FromRow, PgPool};
 use url::Url;
@@ -462,8 +468,8 @@ async fn shorten(url: String, state: &State<AppState>) -> Result<String, status:
 
 static MIGRATOR: Migrator = sqlx::migrate!();
 
-#[shuttle_service::main]
-async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleRocket {
+#[shuttle_runtime::main]
+async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> shuttle_rocket::ShuttleRocket {
     MIGRATOR.run(&pool).await.map_err(CustomError::new)?;
 
     let state = AppState { pool };
@@ -471,7 +477,7 @@ async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleRocket {
         .mount("/", routes![redirect, shorten])
         .manage(state);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 

--- a/examples/salvo.mdx
+++ b/examples/salvo.mdx
@@ -24,8 +24,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-salvo = "0.34.3"
-shuttle-service = { version = "0.11.0", features = ["web-salvo"] }
+salvo = "0.37.5"
+shuttle-salvo = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -37,11 +39,11 @@ async fn hello_world(res: &mut Response) {
     res.render(Text::Plain("Hello, world!"));
 }
 
-#[shuttle_service::main]
-async fn salvo() -> shuttle_service::ShuttleSalvo {
+#[shuttle_runtime::main]
+async fn salvo() -> shuttle_salvo::ShuttleSalvo {
     let router = Router::with_path("hello").get(hello_world);
 
-    Ok(router)
+    Ok(router.into())
 }
 ```
 

--- a/examples/salvo.mdx
+++ b/examples/salvo.mdx
@@ -25,8 +25,8 @@ edition = "2021"
 
 [dependencies]
 salvo = "0.37.5"
-shuttle-salvo = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-salvo = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:

--- a/examples/salvo.mdx
+++ b/examples/salvo.mdx
@@ -23,15 +23,13 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 salvo = "0.34.3"
 shuttle-service = { version = "0.11.0", features = ["web-salvo"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use salvo::prelude::*;
 
 #[handler]

--- a/examples/serenity.mdx
+++ b/examples/serenity.mdx
@@ -38,10 +38,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-shuttle-serenity = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-serenity = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.8.0"
+shuttle-secrets = "0.12.0"
 tokio = { version = "1.26.0" }
 tracing = "0.1.37"
 ```
@@ -158,10 +158,10 @@ edition = "2021"
 anyhow = "1.0.66"
 serde = "1.0.148"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.8.0"
-shuttle-serenity = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+shuttle-secrets = "0.12.0"
+shuttle-serenity = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-shared-db = { version = "0.12.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.26.0" }
 tracing = "0.1.37"

--- a/examples/serenity.mdx
+++ b/examples/serenity.mdx
@@ -36,8 +36,6 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 anyhow = "1.0.62"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
@@ -45,9 +43,9 @@ shuttle-secrets = "0.11.0"
 shuttle-service = { version = "0.11.0", features = ["bot-serenity"] }
 tracing = "0.1.35"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use anyhow::anyhow;
 use serenity::async_trait;
 use serenity::model::channel::Message;
@@ -153,7 +151,6 @@ name = "serenity-postgres"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 
 [dependencies]
 anyhow = "1.0.62"
@@ -165,10 +162,10 @@ shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
 sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
 tracing = "0.1.35"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
-// lib.rs
+```Rust main.rs
+// main.rs
 use anyhow::Context as _;
 use serenity::async_trait;
 use serenity::model::application::command::CommandOptionType;

--- a/examples/serenity.mdx
+++ b/examples/serenity.mdx
@@ -37,11 +37,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.62"
+anyhow = "1.0.66"
+shuttle-serenity = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.11.0"
-shuttle-service = { version = "0.11.0", features = ["bot-serenity"] }
-tracing = "0.1.35"
+shuttle-secrets = "0.8.0"
+tokio = { version = "1.26.0" }
+tracing = "0.1.37"
 ```
 Your `main.rs` should look like this:
 
@@ -71,10 +73,10 @@ impl EventHandler for Bot {
     }
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn serenity(
     #[shuttle_secrets::Secrets] secret_store: SecretStore,
-) -> shuttle_service::ShuttleSerenity {
+) -> shuttle_serenity::ShuttleSerenity {
     // Get the discord token set in `Secrets.toml`
     let token = if let Some(token) = secret_store.get("DISCORD_TOKEN") {
         token
@@ -90,7 +92,7 @@ async fn serenity(
         .await
         .expect("Err creating client");
 
-    Ok(client)
+    Ok(client.into())
 }
 ```
 And your `Secrets.toml` file should look like this (and have your token inside):
@@ -153,14 +155,16 @@ edition = "2021"
 
 
 [dependencies]
-anyhow = "1.0.62"
-serde = "1.0"
+anyhow = "1.0.66"
+serde = "1.0.148"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.11.0"
-shuttle-service = { version = "0.11.0", features = ["bot-serenity"] }
-shuttle-shared-db = { version = "0.11.0", features = ["postgres"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
-tracing = "0.1.35"
+shuttle-secrets = "0.8.0"
+shuttle-serenity = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-shared-db = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tokio = { version = "1.26.0" }
+tracing = "0.1.37"
 ```
 Your `main.rs` should look like this:
 
@@ -291,11 +295,11 @@ impl EventHandler for Bot {
     }
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn serenity(
     #[shuttle_shared_db::Postgres] pool: PgPool,
     #[shuttle_secrets::Secrets] secret_store: SecretStore,
-) -> shuttle_service::ShuttleSerenity {
+) -> shuttle_serenity::ShuttleSerenity {
     // Get the discord token set in `Secrets.toml`
     let token = secret_store
         .get("DISCORD_TOKEN")
@@ -319,7 +323,7 @@ async fn serenity(
         .await
         .expect("Err creating client");
 
-    Ok(client)
+    Ok(client.into())
 }
 ```
 

--- a/examples/shuttle-next.mdx
+++ b/examples/shuttle-next.mdx
@@ -1,0 +1,143 @@
+---
+title: "Shuttle-next"
+description:
+  "Shuttle-next is a batteries-included, WASM-based backend web-framework."
+---
+
+Shuttle-next is a brand new WASM web-framework based on axum and hyper. There are many benefits to
+using WASM for a backend web-framework, but one of the key features is the isolation it offers. Since
+WASM modules have no notion of a file system, a shuttle-next project can only interact with the host
+through resources explicitly declared by us. In this first iteration, the only resource available is
+an HTTP stream to and from a project.
+
+Shuttle-next is very much a work in progress, and we're releasing this iteration without some of the 
+features that make shuttle a pleasure to use, for example the ability to effortlessly deploy and connect 
+to a database. It's also not currently possible to use any middleware. We're planning to implement this 
+functionality, and more, in the near future. We're also hoping that the feedback we get from this release 
+will help us see which features we should prioritize, and which areas of the framework's design need the 
+most attention going forward.
+
+## Hello world!
+
+Simple 'Hello world' app using shuttle-next.
+
+```bash
+cargo new --lib hello-world
+cd hello-world
+```
+
+Make sure that your `Cargo.toml` file looks like the one below -- having the right dependencies is key!
+You'll also notice that this is a `cdylib` and not a binary, like other shuttle projects.
+
+```toml Cargo.toml
+[package]
+name = "hello-world"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+shuttle-next = "0.12.0"
+```
+
+Using the `shuttle-next::app!` macro, we can create HTTP API endpoints, setting the
+method and the route endpoint in the `shuttle::endpoint()` macro arguments. Any function
+that is a valid `axum` handler can be used, and you are free to add functions that aren't
+annotated with the `shuttle_next::endpoint` macro and use them in your handlers. For now,
+everything has to go in the same file, inside the `shuttle_next::app!` macro.
+
+```Rust lib.rs
+shuttle_next::app! {
+    #[shuttle_next::endpoint(method = get, route = "/hello")]
+    async fn hello() -> &'static str {
+        "Hello, World!"
+    }
+}
+```
+
+To test your app locally you'll first need to add the `wasm32-wasi` target:
+
+```bash
+rustup target add wasm32-wasi
+```
+
+And we're ready to start it up:
+
+```bash
+cargo shuttle run
+```
+
+Next, curl it to verify that it's working:
+
+```bash
+curl localhost:8000/hello
+```
+
+We can also add an endpoint that takes the body from the request using the axum `BodyStream`
+extractor, lazily map its bytes to uppercase and stream it back in our response:
+
+First, lets add the `futures` crate to our `Cargo.toml`:
+```
+cargo add futures
+```
+
+```rust lib.rs
+shuttle_next::app! {
+    // We need to add some imports (inside the app! macro), 
+    // all re-exported from axum 0.6
+    use shuttle_next::body::StreamBody;
+    use shuttle_next::extract::BodyStream;
+    use shuttle_next::response::IntoResponse;
+    
+    // We'll also need the futures `TryStreamExt` trait to manipulate 
+    // the body stream
+    use futures::TryStreamExt;
+
+    #[shuttle_next::endpoint(method = post, route = "/uppercase")]
+    async fn uppercase(body: BodyStream) -> impl IntoResponse {
+        let chunk_stream = body.map_ok(|chunk| {
+            chunk
+                .iter()
+                .map(|byte| byte.to_ascii_uppercase())
+                .collect::<Vec<u8>>()
+        });
+        Response::new(StreamBody::new(chunk_stream))
+    }
+}
+```
+
+Let's run it again, and add a body to our request:
+```bash
+curl localhost:8000/uppercase -d "Please convert me to uppercase."
+```
+
+We can also add more handlers with the same route, granted they have different
+HTTP methods:
+
+```Rust lib.rs
+shuttle_next::app! {
+    #[shuttle_next::endpoint(method = get, route = "/hello")]
+    async fn get_hello() -> &'static str {
+        "Hello from get_hello!"
+    }
+
+	#[shuttle_next::endpoint(method = post, route = "/hello")]
+    async fn post_hello() -> &'static str {
+        "Hello from post_hello!"
+    }
+}
+```
+
+Finally, to deploy your app, all you need to do is:
+```bash
+cargo shuttle project new
+```
+
+And then:
+```bash
+cargo shuttle deploy
+```
+
+And your app is live! 🎉🎉🎉

--- a/examples/thruster.mdx
+++ b/examples/thruster.mdx
@@ -25,8 +25,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-service = { version = "0.11.0", features = ["web-thruster"] }
+shuttle-thruster = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
+tokio = { version = "1.26.0" }
 ```
 
 Your `main.rs` should look like this:
@@ -43,11 +45,13 @@ async fn hello(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult
     Ok(context)
 }
 
-#[shuttle_service::main]
-async fn thruster() -> shuttle_service::ShuttleThruster<HyperServer<Ctx, ()>> {
-    Ok(HyperServer::new(
+#[shuttle_runtime::main]
+async fn thruster() -> shuttle_thruster::ShuttleThruster<HyperServer<Ctx, ()>> {
+    let server = HyperServer::new(
         App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/hello", m![hello]),
-    ))
+    );
+    
+    Ok(server.into())
 }
 ```
 
@@ -81,23 +85,28 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hyper = "0.14.20"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
-shuttle-aws-rds = { version = "0.11.0", features = ["postgres"] }
-shuttle-service = { version = "0.11.0", features = ["web-thruster"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+hyper = "0.14.23"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
+shuttle-aws-rds = { version = "0.8.0", features = ["postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+shuttle-thruster = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
+tokio = { version = "1.26.0" }
 ```
 
 Your `main.rs` should look like this:
 
 ```rust main.rs
 use serde::{Deserialize, Serialize};
-use shuttle_service::error::CustomError;
+use shuttle_runtime::CustomError;
 use sqlx::{Executor, FromRow, PgPool};
 use thruster::{
-    context::{hyper_request::HyperRequest, typed_hyper_context::TypedHyperContext},
+    context::{
+        context_ext::ContextExt, hyper_request::HyperRequest,
+        typed_hyper_context::TypedHyperContext,
+    },
     errors::{ErrorSet, ThrusterError},
     m, middleware_fn, App, Context, HyperServer, MiddlewareNext, MiddlewareResult, ThrusterServer,
 };
@@ -136,7 +145,7 @@ fn generate_context(request: HyperRequest, state: &ServerConfig, _path: &str) ->
 #[middleware_fn]
 async fn retrieve(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
     let id: i32 = context
-        .query_params
+        .params()
         .get("id")
         .ok_or_else(|| {
             ThrusterError::parsing_error(
@@ -144,6 +153,7 @@ async fn retrieve(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareRes
                 "id is required",
             )
         })?
+        .param
         .parse()
         .map_err(|_e| {
             ThrusterError::parsing_error(
@@ -166,19 +176,16 @@ async fn retrieve(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareRes
 }
 
 #[middleware_fn]
-async fn add(context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+async fn add(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
     let extra = context.extra.clone();
 
-    let (body, mut context) = context
-        .get_body()
+    let todo_req = context
+        .get_json::<TodoNew>()
         .await
         .map_err(|_e| ThrusterError::generic_error(Ctx::new_without_request(extra)))?;
-    let data: TodoNew = serde_json::from_str(&body).map_err(|_e| {
-        ThrusterError::generic_error(Ctx::new_without_request(context.extra.clone()))
-    })?;
 
     let todo: Todo = sqlx::query_as("INSERT INTO todos(note) VALUES ($1) RETURNING id, note")
-        .bind(&data.note)
+        .bind(&todo_req.note)
         .fetch_one(&context.extra.pool)
         .await
         .map_err(|_e| {
@@ -190,19 +197,21 @@ async fn add(context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> 
     Ok(context)
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn thruster(
     #[shuttle_aws_rds::Postgres] pool: PgPool,
-) -> shuttle_service::ShuttleThruster<HyperServer<Ctx, ServerConfig>> {
+) -> shuttle_thruster::ShuttleThruster<HyperServer<Ctx, ServerConfig>> {
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;
 
-    Ok(HyperServer::new(
+    let server = HyperServer::new(
         App::<HyperRequest, Ctx, ServerConfig>::create(generate_context, ServerConfig { pool })
             .post("/todos", m![add])
             .get("/todos/:id", m![retrieve]),
-    ))
+    );
+    
+    Ok(server.into())
 }
 ```
 

--- a/examples/thruster.mdx
+++ b/examples/thruster.mdx
@@ -24,16 +24,14 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 shuttle-service = { version = "0.11.0", features = ["web-thruster"] }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```rust lib.rs
+```rust main.rs
 use thruster::{
     context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
     m, middleware_fn, App, HyperServer, MiddlewareNext, MiddlewareResult, ThrusterServer,
@@ -79,7 +77,6 @@ name = "postgres"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -93,9 +90,9 @@ sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```rust lib.rs
+```rust main.rs
 use serde::{Deserialize, Serialize};
 use shuttle_service::error::CustomError;
 use sqlx::{Executor, FromRow, PgPool};

--- a/examples/thruster.mdx
+++ b/examples/thruster.mdx
@@ -25,8 +25,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-thruster = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-thruster = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
 tokio = { version = "1.26.0" }
 ```
@@ -88,10 +88,10 @@ crate-type = ["cdylib"]
 hyper = "0.14.23"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
-shuttle-aws-rds = { version = "0.8.0", features = ["postgres"] }
+shuttle-aws-rds = { version = "0.12.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
-shuttle-thruster = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-thruster = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 thruster = { version = "1.3.0", features = ["hyper_server"] }
 tokio = { version = "1.26.0" }
 ```

--- a/examples/tide.mdx
+++ b/examples/tide.mdx
@@ -25,20 +25,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-service = { version = "0.11.0", features = ["web-tide"] }
+shuttle-tide = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 tide = "0.16.0"
 ```
 Your `main.rs` should look like this:
 
 ```Rust main.rs
-#[shuttle_service::main]
-async fn tide() -> shuttle_service::ShuttleTide<()> {
+#[shuttle_runtime::main]
+async fn tide() -> shuttle_tide::ShuttleTide<()> {
     let mut app = tide::new();
     app.with(tide::log::LogMiddleware::new());
 
     app.at("/hello").get(|_| async { Ok("Hello, world!") });
 
-    Ok(app)
+    Ok(app.into())
 }
 ```
 
@@ -69,10 +71,12 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-shuttle-aws-rds = { version = "0.11.0", features = ["postgres"] }
-shuttle-service = { version = "0.11.0", features = ["web-tide"] }
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
+serde = { version = "1.0.148", features = ["derive"] }
+shuttle-aws-rds = { version = "0.8.0", features = ["postgres"] }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-tide = { version = "0.1.0" }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
+tokio = { version = "1.26.0" }
 tide = "0.16.0"
 ```
 
@@ -80,7 +84,8 @@ Your `main.rs` should look like this:
 
 ```rust main.rs
 use serde::{Deserialize, Serialize};
-use shuttle_service::{error::CustomError, ShuttleTide};
+use shuttle_runtime::{CustomError};
+use shuttle_tide::ShuttleTide;
 use sqlx::{Executor, FromRow, PgPool};
 use tide::{Body, Request};
 
@@ -109,7 +114,7 @@ struct MyState {
     pool: PgPool,
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn tide(#[shuttle_aws_rds::Postgres] pool: PgPool) -> ShuttleTide<MyState> {
     pool.execute(include_str!("../schema.sql"))
         .await
@@ -122,9 +127,8 @@ async fn tide(#[shuttle_aws_rds::Postgres] pool: PgPool) -> ShuttleTide<MyState>
     app.at("/todo").post(add);
     app.at("/todo/:id").get(retrieve);
 
-    Ok(app)
+    Ok(app.into())
 }
-
 
 #[derive(Deserialize)]
 struct TodoNew {

--- a/examples/tide.mdx
+++ b/examples/tide.mdx
@@ -24,15 +24,13 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 shuttle-service = { version = "0.11.0", features = ["web-tide"] }
 tide = "0.16.0"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 #[shuttle_service::main]
 async fn tide() -> shuttle_service::ShuttleTide<()> {
     let mut app = tide::new();
@@ -67,7 +65,6 @@ name = "postgres"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
 crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -79,9 +76,9 @@ sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres"] }
 tide = "0.16.0"
 ```
 
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```rust lib.rs
+```rust main.rs
 use serde::{Deserialize, Serialize};
 use shuttle_service::{error::CustomError, ShuttleTide};
 use sqlx::{Executor, FromRow, PgPool};

--- a/examples/tide.mdx
+++ b/examples/tide.mdx
@@ -25,8 +25,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-tide = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-tide = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 tide = "0.16.0"
 ```
@@ -72,9 +72,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-aws-rds = { version = "0.8.0", features = ["postgres"] }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-tide = { version = "0.1.0" }
+shuttle-aws-rds = { version = "0.12.0", features = ["postgres"] }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-tide = { version = "0.12.0" }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.26.0" }
 tide = "0.16.0"

--- a/examples/tower.mdx
+++ b/examples/tower.mdx
@@ -25,8 +25,8 @@ edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14.23", features = ["full"] }
-shuttle-runtime = { version = "0.1.0" }
-shuttle-tower = { version = "0.1.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-tower = { version = "0.12.0" }
 tower = { version = "0.4.13", features = ["full"] }
 tokio = { version = "1.26.0" }
 ```

--- a/examples/tower.mdx
+++ b/examples/tower.mdx
@@ -23,16 +23,14 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }
 shuttle-service = { version = "0.11.0", features = ["web-tower"] }
 tower = { version = "0.4", features = ["full"] }
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;

--- a/examples/tower.mdx
+++ b/examples/tower.mdx
@@ -24,9 +24,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14", features = ["full"] }
-shuttle-service = { version = "0.11.0", features = ["web-tower"] }
-tower = { version = "0.4", features = ["full"] }
+hyper = { version = "0.14.23", features = ["full"] }
+shuttle-runtime = { version = "0.1.0" }
+shuttle-tower = { version = "0.1.0" }
+tower = { version = "0.4.13", features = ["full"] }
+tokio = { version = "1.26.0" }
 ```
 Your `main.rs` should look like this:
 
@@ -61,9 +63,11 @@ impl tower::Service<hyper::Request<hyper::Body>> for HelloWorld {
     }
 }
 
-#[shuttle_service::main]
-async fn tower() -> Result<HelloWorld, shuttle_service::Error> {
-    Ok(HelloWorld)
+#[shuttle_runtime::main]
+async fn tower() -> shuttle_tower::ShuttleTower<HelloWorld> {
+    let service = HelloWorld;
+
+    Ok(service.into())
 }
 ```
 

--- a/examples/warp.mdx
+++ b/examples/warp.mdx
@@ -23,8 +23,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-runtime = { version = "0.1.0" }
-shuttle-warp = { version = "0.1.0" }
+shuttle-runtime = { version = "0.12.0" }
+shuttle-warp = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 warp = "0.3.3"
 ```

--- a/examples/warp.mdx
+++ b/examples/warp.mdx
@@ -23,8 +23,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-shuttle-service = { version = "0.11.0", features = ["web-warp"] }
-warp = "0.3.2"
+shuttle-runtime = { version = "0.1.0" }
+shuttle-warp = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
+warp = "0.3.3"
 ```
 Your `main.rs` should look like this:
 
@@ -32,10 +34,10 @@ Your `main.rs` should look like this:
 use warp::Filter;
 use warp::Reply;
 
-#[shuttle_service::main]
-async fn warp() -> shuttle_service::ShuttleWarp<(impl Reply,)> {
-    let route = warp::any().map(|| "Hello, World");
-    Ok(route.boxed())
+#[shuttle_runtime::main]
+async fn warp() -> shuttle_warp::ShuttleWarp<(impl Reply,)> {
+    let route = warp::any().map(|| "Hello, World!");
+    Ok(route.boxed().into())
 }
 ```
 

--- a/examples/warp.mdx
+++ b/examples/warp.mdx
@@ -22,15 +22,13 @@ name = "hello-world"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 shuttle-service = { version = "0.11.0", features = ["web-warp"] }
 warp = "0.3.2"
 ```
-Your `lib.rs` should look like this:
+Your `main.rs` should look like this:
 
-```Rust lib.rs
+```Rust main.rs
 use warp::Filter;
 use warp::Reply;
 

--- a/introduction/local-run.mdx
+++ b/introduction/local-run.mdx
@@ -22,7 +22,7 @@ URI, simply pass it in as an argument to your resource. This argument also suppo
 with string interpolation:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn tide(#[shuttle_aws_rds::Postgres(
         local_uri = "postgres://postgres:{secrets.PASSWORD}@localhost:16695/postgres"
     )] pool: PgPool) -> ShuttleTide<MyState> { ... }

--- a/introduction/telemetry.mdx
+++ b/introduction/telemetry.mdx
@@ -5,7 +5,7 @@ description: "Using `tracing` or `log` with shuttle apps."
 
 ## Tracing
 
-When you build an app with the `#[shuttle_service::main]` macro, a global subscriber will be created and installed
+When you build an app with the `#[shuttle_runtime::main]` macro, a global subscriber will be created and installed
 [behind the scenes](https://github.com/shuttle-hq/shuttle/blob/001dbcfcf47066713598f00a98f4972de450ff3b/codegen/src/main/mod.rs#L237-L245).
 This means if you can skip this step when implementing [tracing](https://docs.rs/tracing/latest/tracing/) in your application, 
 all you have to do is add `tracing` as a dependency in your `Cargo.toml`, and you're good to go!
@@ -14,7 +14,7 @@ all you have to do is add `tracing` as a dependency in your `Cargo.toml`, and yo
 // [...]
 use tracing::info;
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn axum(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleAxum { 
     info!("Running database migration");
     pool.execute(include_str!("../schema.sql"))

--- a/introduction/what-is-shuttle.mdx
+++ b/introduction/what-is-shuttle.mdx
@@ -38,7 +38,7 @@ deployed with a one-liner, as well as dependencies like databases being
 provisioned through static analysis in real-time.
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn rocket(
     #[shuttle_shared_db::Postgres] pool: PgPool, // automatic db provisioning + hands you back an authenticated connection pool
 ) -> ShuttleRocket<...> {

--- a/mint.json
+++ b/mint.json
@@ -4,11 +4,6 @@
     "light": "/images/logo/light.png",
     "dark": "/images/logo/dark.png"
   },
-  "analytics": {
-    "ga4": {
-      "measurementId": "G-KR6NKW20JH"
-    }
-  },
   "favicon": "/favicon.png",
   "colors": {
     "primary": "#F25100",
@@ -66,6 +61,7 @@
         "examples/poem",
         "examples/rocket",
         "examples/salvo",
+        "examples/shuttle-next",
         "examples/serenity",
         "examples/thruster",
         "examples/tide",
@@ -86,10 +82,7 @@
     },
     {
       "group": "Support",
-      "pages": [
-        "support/faq",
-        "support/troubleshooting"
-      ]
+      "pages": ["support/faq", "support/troubleshooting"]
     },
     {
       "group": "Resources",

--- a/resources/shuttle-aws-rds.mdx
+++ b/resources/shuttle-aws-rds.mdx
@@ -25,7 +25,7 @@ When setting the `local_uri` you can also insert secrets from `Secrets.toml` usi
 `PASSWORD` secret, pass it in like this:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn tide(#[shuttle_aws_rds::Postgres(
         local_uri = "postgres://postgres:{secrets.PASSWORD}@localhost:16695/postgres"
     )] pool: PgPool) -> ShuttleTide<MyState> { ... }
@@ -36,7 +36,7 @@ This snippet shows the main function of a tide app that uses the `shuttle_aws_rd
 It gives you an authenticated  [sqlx Pool](https://docs.rs/sqlx/latest/sqlx/pool/index.html), which you can use to interact with the database.
 
 ```rust main.rs
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn tide(#[shuttle_aws_rds::Postgres] pool: PgPool) -> ShuttleTide<MyState> {
     pool.execute(include_str!("../schema.sql"))
         .await
@@ -49,7 +49,7 @@ async fn tide(#[shuttle_aws_rds::Postgres] pool: PgPool) -> ShuttleTide<MyState>
     app.at("/todo").post(add);
     app.at("/todo/:id").get(retrieve);
 
-    Ok(app)
+    Ok(app.into())
 }
 ```
 

--- a/resources/shuttle-aws-rds.mdx
+++ b/resources/shuttle-aws-rds.mdx
@@ -35,7 +35,7 @@ async fn tide(#[shuttle_aws_rds::Postgres(
 This snippet shows the main function of a tide app that uses the `shuttle_aws_rds::Postgres` attribute to provision an RDS Postgres database.
 It gives you an authenticated  [sqlx Pool](https://docs.rs/sqlx/latest/sqlx/pool/index.html), which you can use to interact with the database.
 
-```rust lib.rs
+```rust main.rs
 #[shuttle_service::main]
 async fn tide(#[shuttle_aws_rds::Postgres] pool: PgPool) -> ShuttleTide<MyState> {
     pool.execute(include_str!("../schema.sql"))

--- a/resources/shuttle-persist.mdx
+++ b/resources/shuttle-persist.mdx
@@ -10,7 +10,7 @@ Add `shuttle-persist` to the dependencies for your service. You can get this res
 ## Example
 This snippet shows a shuttle rocket main function that uses the `shuttle_persist::Persist` attribute to provision and get access to a `PersistInstance`.
 
-```rust lib.rs
+```rust main.rs
 #[shuttle_service::main]
 async fn rocket(
     #[shuttle_persist::Persist] persist: PersistInstance,

--- a/resources/shuttle-persist.mdx
+++ b/resources/shuttle-persist.mdx
@@ -11,16 +11,16 @@ Add `shuttle-persist` to the dependencies for your service. You can get this res
 This snippet shows a shuttle rocket main function that uses the `shuttle_persist::Persist` attribute to provision and get access to a `PersistInstance`.
 
 ```rust main.rs
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn rocket(
     #[shuttle_persist::Persist] persist: PersistInstance,
-) -> shuttle_service::ShuttleRocket {
+) -> ShuttleRocket {
     let state = MyState { persist };
     let rocket = rocket::build()
         .mount("/", routes![retrieve, add])
         .manage(state);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 

--- a/resources/shuttle-secrets.mdx
+++ b/resources/shuttle-secrets.mdx
@@ -22,7 +22,7 @@ files.
 ## Example
 This snippet shows a shuttle rocket main function that uses the `shuttle_secrets::Secrets` attribute to gain access to a `SecretStore`.
 
-```rust lib.rs
+```rust main.rs
 #[shuttle_service::main]
 async fn rocket(
     #[shuttle_secrets::Secrets] secret_store: SecretStore,

--- a/resources/shuttle-secrets.mdx
+++ b/resources/shuttle-secrets.mdx
@@ -8,7 +8,7 @@ This plugin manages secrets on [shuttle](https://www.shuttle.rs).
 Add `shuttle-secrets` to the dependencies for your service, and add a `Secrets.toml` to the root of your project
 with the secrets you'd like to store. Make sure to add `Secrets.toml` to a `.gitignore` to omit your secrets from version control.
 
-Next, pass `#[shuttle_secrets::Secrets] secret_store: SecretStore` as an argument to your `shuttle_service::main` function.
+Next, pass `#[shuttle_secrets::Secrets] secret_store: SecretStore` as an argument to your `shuttle_runtime::main` function.
 `SecretStore::get` can now be called to retrieve your API keys and other secrets at runtime.
 
 ## Local secrets
@@ -23,10 +23,10 @@ files.
 This snippet shows a shuttle rocket main function that uses the `shuttle_secrets::Secrets` attribute to gain access to a `SecretStore`.
 
 ```rust main.rs
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn rocket(
     #[shuttle_secrets::Secrets] secret_store: SecretStore,
-) -> shuttle_service::ShuttleRocket {
+) -> ShuttleRocket {
     // get secret defined in `Secrets.toml` file.
     let secret = if let Some(secret) = secret_store.get("MY_API_KEY") {
         secret
@@ -37,7 +37,7 @@ async fn rocket(
     let state = MyState { secret };
     let rocket = rocket::build().mount("/", routes![secret]).manage(state);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 

--- a/resources/shuttle-shared-db.mdx
+++ b/resources/shuttle-shared-db.mdx
@@ -22,10 +22,10 @@ When setting the `local_uri` you can also insert secrets from `Secrets.toml` usi
 `PASSWORD` secret, pass it in like this:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn poem(#[shuttle_shared_db::Postgres(
         local_uri = "postgres://postgres:{secrets.PASSWORD}@localhost:16695/postgres"
-    )] pool: PgPool) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> { ... }
+    )] pool: PgPool) -> ShuttlePoem<impl poem::Endpoint> { ... }
 ```
 
 ## Example
@@ -33,10 +33,10 @@ The shuttle poem main function below uses the `[shuttle_shared_db::Postgres]` at
 which can be accessed using a pre-configured, authenticated [sqlx Pool](https://docs.rs/sqlx/latest/sqlx/pool/index.html).
 
 ```rust main.rs
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn poem(
     #[shuttle_shared_db::Postgres] pool: PgPool,
-) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+) -> ShuttlePoem<impl poem::Endpoint> {
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;
@@ -46,7 +46,7 @@ async fn poem(
         .at("/todo/:id", get(retrieve))
         .with(AddData::new(pool));
 
-    Ok(app)
+    Ok(app.into())
 }
 ```
 

--- a/resources/shuttle-shared-db.mdx
+++ b/resources/shuttle-shared-db.mdx
@@ -32,7 +32,7 @@ async fn poem(#[shuttle_shared_db::Postgres(
 The shuttle poem main function below uses the `[shuttle_shared_db::Postgres]` attribute macro to provision a shared postgres database,
 which can be accessed using a pre-configured, authenticated [sqlx Pool](https://docs.rs/sqlx/latest/sqlx/pool/index.html).
 
-```rust lib.rs
+```rust main.rs
 #[shuttle_service::main]
 async fn poem(
     #[shuttle_shared_db::Postgres] pool: PgPool,

--- a/resources/shuttle-static-folder.mdx
+++ b/resources/shuttle-static-folder.mdx
@@ -10,7 +10,7 @@ Add `shuttle-static-folder` to the dependencies for your service. This resource 
 An example using the Axum framework can be found on [GitHub](https://github.com/shuttle-hq/examples/tree/main/axum/static-files)
 
 ``` rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn main(
     #[shuttle_static_folder::StaticFolder] static_folder: PathBuf,
 ) -> __ { ... }
@@ -25,7 +25,7 @@ async fn main(
 Since this plugin defaults to the `static` folder, the arguments can be used to use the `public` folder instead.
 
 ``` rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn main(
     #[shuttle_static_folder::StaticFolder(folder = "public")] public_folder: PathBuf,
 ) -> __ { ... }

--- a/support/troubleshooting.mdx
+++ b/support/troubleshooting.mdx
@@ -36,7 +36,7 @@ This section is aimed at collecting common issues users have to provide quick de
   <Accordion title="How can I handle environment variables?">
     Add **`shuttle-secrets`** to the dependencies for your service, and add a **`Secrets.toml`** to the root of your project with the secrets you'd like to store. Make sure to add **`Secrets.toml`** to a **`.gitignore`** to omit your secrets from version control.
 
-    Next, pass **`#[shuttle_secrets::Secrets] secret_store: SecretStore`** as an argument to your **`shuttle_service::main`** function. **`SecretStore::get`** can now be called to retrieve your API keys and other secrets at runtime.
+    Next, pass **`#[shuttle_secrets::Secrets] secret_store: SecretStore`** as an argument to your **`shuttle_runtime::main`** function. **`SecretStore::get`** can now be called to retrieve your API keys and other secrets at runtime.
 
     For more details, and an explanation on how to use local secrets, head on over here: [shuttle secrets](https://docs.shuttle.rs/resources/shuttle-secrets).
   </Accordion>

--- a/tutorials/authentication.mdx
+++ b/tutorials/authentication.mdx
@@ -30,7 +30,7 @@ This isn't verified to be secure, use it at your own risk!!
 
 First, we will install shuttle for creating the project (and later for deployment). If you don't already have it you can install it with `cargo install cargo-shuttle`. We will first go to a new directory for our project and create a new Axum app with `cargo shuttle init --axum`.
 
-You should see the following in `src/lib.rs`:
+You should see the following in `src/main.rs`:
 
 ```rust
 use axum::{routing::get, Router}; use sync_wrapper::SyncWrapper;
@@ -823,7 +823,7 @@ opinions while building the site as well as things you could try extending it
 with.
 
 For templating Tera is great. I like how I separate the markup into external
-files rather than bundling it into `src/lib.rs`. Its API is easy to use and is
+files rather than bundling it into `src/main.rs`. Its API is easy to use and is
 well documented. However, it is quite a simple system. I had a few errors where
 I would rename or remove templates and because the template picker for rendering
 uses a map it can panic at runtime if the template does not exist. It would be

--- a/tutorials/authentication.mdx
+++ b/tutorials/authentication.mdx
@@ -33,16 +33,14 @@ First, we will install shuttle for creating the project (and later for deploymen
 You should see the following in `src/main.rs`:
 
 ```rust
-use axum::{routing::get, Router}; use sync_wrapper::SyncWrapper;
+use axum::{routing::get, Router};
 
 async fn hello_world() -> &'static str { "Hello, world!" }
 
-#[shuttle_service::main] async fn axum() -> shuttle_service::ShuttleAxum { let
-router = Router::new().route("/hello", get(hello_world)); let sync_wrapper =
-SyncWrapper::new(router);
+#[shuttle_service::main] async fn axum() -> shuttle_service::ShuttleAxum { 
+    let router = Router::new().route("/hello", get(hello_world)); 
 
-    Ok(sync_wrapper)
-
+    Ok(router)
 }
 ```
 
@@ -123,8 +121,7 @@ async fn axum() -> shuttle_service::ShuttleAxum {
         .route("/hello", get(hello_world))
         .layer(Extension(Arc::new(tera)));
 
-    let sync_wrapper = SyncWrapper::new(router);
-    Ok(sync_wrapper)
+    Ok(router)
 }
 ```
 

--- a/tutorials/authentication.mdx
+++ b/tutorials/authentication.mdx
@@ -37,10 +37,10 @@ use axum::{routing::get, Router};
 
 async fn hello_world() -> &'static str { "Hello, world!" }
 
-#[shuttle_service::main] async fn axum() -> shuttle_service::ShuttleAxum { 
+#[shuttle_runtime::main] async fn axum() -> shuttle_axum::ShuttleAxum { 
     let router = Router::new().route("/hello", get(hello_world)); 
 
-    Ok(router)
+    Ok(router.into())
 }
 ```
 
@@ -108,8 +108,8 @@ tera.add_raw_templates(vec![
 We add it via an [Extension](https://docs.rs/axum/latest/axum/struct.Extension.html)(wrapped in `Arc` so that extension cloning does not deep clone all the templates)
 
 ```rust
-#[shuttle_service::main]
-async fn axum() -> shuttle_service::ShuttleAxum {
+#[shuttle_runtime::main]
+async fn axum() -> shuttle_axum::ShuttleAxum {
     let mut tera = Tera::default();
     tera.add_raw_templates(vec![
         ("base.html", include_str!("../templates/base.html")),
@@ -121,7 +121,7 @@ async fn axum() -> shuttle_service::ShuttleAxum {
         .route("/hello", get(hello_world))
         .layer(Extension(Arc::new(tera)));
 
-    Ok(router)
+    Ok(router.into())
 }
 ```
 
@@ -221,7 +221,7 @@ Postgres database using the
 ```rust
 type Database = sqlx::PgPool;
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn axum(
     #[shuttle_shared_db::Postgres] pool: Database
 ) -> ShuttleAxum {
@@ -450,7 +450,7 @@ arc and a mutex because generating new identifiers requires mutable access. We
 now have the following main function:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn axum(
     #[shuttle_shared_db::Postgres] pool: Database
 ) -> ShuttleAxum {
@@ -655,7 +655,7 @@ user it results in one database request, not two!
 We can add the middleware to our chain using:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn axum(
     #[shuttle_shared_db::Postgres] pool: Database
 ) -> ShuttleAxum {
@@ -778,7 +778,7 @@ seen before but for a login screen. At the end of that we can add two new routes
 with three handlers completing the demo:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn axum(
     #[shuttle_shared_db::Postgres] pool: Database
 ) -> ShuttleAxum {
@@ -802,7 +802,7 @@ interwebs. Luckily we are using shuttle, so it is as simple as:
 
 `cargo shuttle deploy`
 
-Because of our `#[shuttle_service::main]` annotation and out-the-box Axum
+Because of our `#[shuttle_runtime::main]` annotation and out-the-box Axum
 support our deployment doesn't need any prior config, it is instantly live!
 
 Now you can go ahead with these concepts and add functionality for listing and

--- a/tutorials/discord-weather-forecast.mdx
+++ b/tutorials/discord-weather-forecast.mdx
@@ -76,9 +76,9 @@ directory:
 cargo shuttle init --serenity
 ```
 
-After running it you, should see the following generated in `src/lib.rs`:
+After running it you, should see the following generated in `src/main.rs`:
 
-```rust src/lib.rs
+```rust src/main.rs
 use anyhow::Context as _;
 use serenity::model::application::interaction::{Interaction, InteractionResponseType};
 use serenity::model::gateway::Ready;
@@ -410,7 +410,7 @@ add some fields to our bot for holding this data and initialize this in the
 weather API key:
 
 ```rust
-// In lib.rs
+// In main.rs
 struct Bot {
     weather_api_key: String,
     client: reqwest::Client,

--- a/tutorials/discord-weather-forecast.mdx
+++ b/tutorials/discord-weather-forecast.mdx
@@ -102,12 +102,13 @@ impl EventHandler for Bot {
     }
     async fn ready(&self, _: Context, ready: Ready) {
         info!("{} is connected!", ready.user.name);
+    }
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn serenity(
     #[shuttle_secrets::Secrets] secret_store: SecretStore,
-) -> shuttle_service::ShuttleSerenity {
+) -> shuttle_serenity::ShuttleSerenity {
     // Get the discord token set in `Secrets.toml`
     let discord_token = secret_store
         .get("DISCORD_TOKEN")
@@ -124,7 +125,7 @@ async fn serenity(
         )
         .await;
 
-        Ok(client)
+        Ok(client.into())
     }
 ```
 
@@ -171,6 +172,7 @@ impl EventHandler for Bot {
 
         info!("Registered commands: {:#?}", commands);
     }
+}
 ```
 
 > Serenity has a bit of a different way of registering commands using a
@@ -406,7 +408,7 @@ we can wire that into the bots logic.
 
 Our `get_forecast` requires a `reqwest` Client and the weather API key. We will
 add some fields to our bot for holding this data and initialize this in the
-`shuttle_service::main` function. Using the secrets feature we can get our
+`shuttle_runtime::main` function. Using the secrets feature we can get our
 weather API key:
 
 ```rust
@@ -417,10 +419,10 @@ struct Bot {
     discord_guild_id: GuildId,
 }
 
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn serenity(
     #[shuttle_secrets::Secrets] secret_store: SecretStore,
-) -> shuttle_service::ShuttleSerenity {
+) -> shuttle_srenity::ShuttleSerenity {
     // Get the discord token set in `Secrets.toml`
     let discord_token = secret_store
         .get("DISCORD_TOKEN")
@@ -440,7 +442,7 @@ async fn serenity(
         discord_guild_id.parse().unwrap(),
     )
     .await;
- Ok(client)
+    Ok(client.into())
 }
 
 

--- a/tutorials/serverless-calendar-app.mdx
+++ b/tutorials/serverless-calendar-app.mdx
@@ -104,7 +104,6 @@ and I was greeted with everything I needed to get started:
 
 ```rust
 use axum::{routing::get, Router};
-use sync_wrapper::SyncWrapper;
 
 async fn hello_world() -> &'static str {
   "Hello, world!"
@@ -113,9 +112,8 @@ async fn hello_world() -> &'static str {
 #[shuttle_service::main]
 async fn axum() -> shuttle_service::ShuttleAxum {
   let router = Router::new().route("/hello", get(hello_world));
-  let sync_wrapper = SyncWrapper::new(router);
 
-  Ok(sync_wrapper)
+  Ok(router)
 }
 ```
 

--- a/tutorials/serverless-calendar-app.mdx
+++ b/tutorials/serverless-calendar-app.mdx
@@ -109,11 +109,11 @@ async fn hello_world() -> &'static str {
   "Hello, world!"
 }
 
-#[shuttle_service::main]
-async fn axum() -> shuttle_service::ShuttleAxum {
+#[shuttle_runtime::main]
+async fn axum() -> shuttle_axum::ShuttleAxum {
   let router = Router::new().route("/hello", get(hello_world));
 
-  Ok(router)
+  Ok(router.into())
 }
 ```
 

--- a/tutorials/url-shortener.mdx
+++ b/tutorials/url-shortener.mdx
@@ -110,11 +110,11 @@ fn index() -> &'static str {
     "Hello, world!"
 }
 
-#[shuttle_service::main]
-async fn rocket() -> shuttle_service::ShuttleRocket {
+#[shuttle_runtime::main]
+async fn rocket() -> shuttle_rocket::ShuttleRocket {
     let rocket = rocket::build().mount("/hello", routes![index]);
 
-    Ok(rocket)
+    Ok(rocket.into())
 }
 ```
 
@@ -129,7 +129,9 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0-rc.2"
-shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
+shuttle-rocket = { version = "0.1.0" }
+shuttle-runtime = { version = "0.1.0" }
+tokio = { version = "1.26.0" }
 ```
 
 The `init` command also created a new shuttle project for us. This starts an
@@ -186,7 +188,7 @@ section in the docs. I added the `sqlx` dependency to `Cargo.toml` and change
 one line in `main.rs`:
 
 ```rust
-#[shuttle_service::main]
+#[shuttle_runtime::main]
 async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleRocket {
     // [...]
 }

--- a/tutorials/url-shortener.mdx
+++ b/tutorials/url-shortener.mdx
@@ -129,8 +129,8 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0-rc.2"
-shuttle-rocket = { version = "0.1.0" }
-shuttle-runtime = { version = "0.1.0" }
+shuttle-rocket = { version = "0.12.0" }
+shuttle-runtime = { version = "0.12.0" }
 tokio = { version = "1.26.0" }
 ```
 
@@ -152,7 +152,7 @@ $ cargo shuttle deploy
    Compiling rocket_http v0.5.0-rc.1
    Compiling rocket_codegen v0.5.0-rc.1
    Compiling rocket v0.5.0-rc.1
-   Compiling shuttle-service v0.11.0
+   Compiling shuttle-service v0.12.0
    Compiling url-shortener v0.1.0 (/opt/shuttle/crates/url-shortener)
     Finished dev [unoptimized + debuginfo] target(s) in 1m 01s
 

--- a/tutorials/url-shortener.mdx
+++ b/tutorials/url-shortener.mdx
@@ -99,9 +99,9 @@ To initialize a rocket project with boilerplate, I can use the shuttle CLI `init
 cargo shuttle init --rocket url-shortener
 ```
 
-This leaves me with the following `lib.rs` file:
+This leaves me with the following `main.rs` file:
 
-```rust lib.rs
+```rust main.rs
 #[macro_use]
 extern crate rocket;
 
@@ -127,8 +127,6 @@ name = "url-shortener"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-
 [dependencies]
 rocket = "0.5.0-rc.2"
 shuttle-service = { version = "0.11.0", features = ["web-rocket"] }
@@ -144,7 +142,7 @@ $ cargo shuttle deploy
    Packaging url-shortener v0.1.0 (/private/shuttle/examples/url-shortener)
    Archiving Cargo.toml
    Archiving Cargo.toml.orig
-   Archiving src/lib.rs
+   Archiving src/main.rs
    Compiling tracing-attributes v0.1.20
    Compiling tokio-util v0.6.9
    Compiling multer v2.0.2
@@ -185,7 +183,7 @@ Shuttle does a lot of this stuff for you - I just didn't remember how. I
 quickly head over to the
 [shuttle shared database](https://docs.shuttle.rs/resources/shuttle-shared-db)
 section in the docs. I added the `sqlx` dependency to `Cargo.toml` and change
-one line in `lib.rs`:
+one line in `main.rs`:
 
 ```rust
 #[shuttle_service::main]

--- a/tutorials/websocket-chat-app-js.mdx
+++ b/tutorials/websocket-chat-app-js.mdx
@@ -223,15 +223,10 @@ For the back end part, because we'll be serving the web server through shuttle, 
 cargo install cargo-shuttle
 ```
 
-You can also use binstall to install cargo-shuttle, like so:
+You can also use [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) to install cargo-shuttle:
 
 ```bash
-// linux
-cargo binstall cargo-shuttle --pkg-url="https://github.com/shuttle-hq/shuttle/releases/download/v0.9.0/cargo-shuttle-v0.9.0-8-gf75c2e9-<target>.tar.gz" --bin-dir="shuttle/cargo-shuttle" --pkg-fmt="tgz"
-
-// Use the command below if you use windows:
-cargo binstall cargo-shuttle --pkg-url="https://github.com/shuttle-hq/shuttle/releases/download/v0.9.0/cargo-shuttle-v0.9.0-8-gf75c2e9-<target>.tar.gz" --bin-dir="shuttle/cargo-shuttle.exe" --pkg-fmt="tgz"
-
+cargo binstall cargo-shuttle\
 ```
 
 The installation may take a while depending on your Internet connection, so feel free to grab a drink while you wait. You will also want to log onto their website here through GitHub and make sure you have your API key as you will need to log in on the CLI with your key before you can make any projects.
@@ -262,9 +257,9 @@ hyper = { version = "0.14", features = ["client", "http2"] }
 hyper-tls = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-secrets = "0.11.0"
-shuttle-service = { version = "0.11.0", features = ["web-axum"] }
-shuttle-static-folder = "0.11.3"
+shuttle-secrets = "0.12.0"
+shuttle-service = { version = "0.12.0", features = ["web-axum"] }
+shuttle-static-folder = "0.12.0"
 sync_wrapper = "0.1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.3.5", features = ["fs", "auth"]}

--- a/tutorials/websocket-chat-app-js.mdx
+++ b/tutorials/websocket-chat-app-js.mdx
@@ -315,9 +315,8 @@ Let's quickly make up our main function so that we have a working route that we 
 #[shuttle_service::main]
 async fn main() -> ShuttleAxum {
 
-    // set up router with Secrets & use syncwrapper to make the web service work
+    // set up router with Secrets
     let router = router(secret, static_folder);
-    let sync_wrapper = SyncWrapper::new(router);
 
     Ok(sync_wrapper)
 }
@@ -330,6 +329,7 @@ fn router(secret: String, static_folder: PathBuf) -> Router {
      Router::new()
         .route("/ws", get(ws_handler))
         .layer(Extension(users))
+}
 ```
 
 Now at the moment we have our main application loop and a router, but as you may have noticed, `ws_handler` doesn't actually exist in our code at the moment. This is what we will be writing next, and it can be simply written as so:
@@ -437,11 +437,10 @@ async fn main(
     // We use Secrets.toml to set the BEARER key, just like in a .env file and call it here
     let secret = secrets.get("BEARER").unwrap_or("Bear".to_string());
 
-    // set up router with Secrets & use syncwrapper to make the web service work
+    // set up router with Secrets
     let router = router(secret);
-    let sync_wrapper = SyncWrapper::new(router);
 
-    Ok(sync_wrapper)
+    Ok(router)
 }
 ```
 
@@ -558,11 +557,10 @@ async fn main(
     // We use Secrets.toml to set the BEARER key, just like in a .env file and call it here
     let secret = secrets.get("BEARER").unwrap_or("Bear".to_string());
 
-    // set up router with Secrets & use syncwrapper to make the web service work
+    // set up router with Secrets
     let router = router(secret, static_folder);
-    let sync_wrapper = SyncWrapper::new(router);
 
-    Ok(sync_wrapper)
+    Ok(router)
 }
 
 fn router(secret: String, static_folder: PathBuf) -> Router {

--- a/tutorials/websocket-chat-app-js.mdx
+++ b/tutorials/websocket-chat-app-js.mdx
@@ -312,13 +312,12 @@ AtomicUsize is used for user IDs as we will want the value to be shared safely a
 Let's quickly make up our main function so that we have a working route that we can test with our front end:
 
 ```rust
-#[shuttle_service::main]
-async fn main() -> ShuttleAxum {
-
+#[shuttle_runtime::main]
+async fn axum() -> ShuttleAxum {
     // set up router with Secrets
     let router = router(secret, static_folder);
 
-    Ok(sync_wrapper)
+    Ok(router.into())
 }
 
 fn router(secret: String, static_folder: PathBuf) -> Router {
@@ -428,19 +427,18 @@ Now while the app is now technically a minimum viable product, there's a couple 
 Before we get started however, let's quickly update our main function so that we can quickly pull in our environment variables and use static assets:
 
 ```rust
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn axum(
     #[shuttle_secrets::Secrets] secrets: SecretStore,
     #[shuttle_static_folder::StaticFolder] static_folder: PathBuf
 ) -> ShuttleAxum {
-
     // We use Secrets.toml to set the BEARER key, just like in a .env file and call it here
     let secret = secrets.get("BEARER").unwrap_or("Bear".to_string());
 
     // set up router with Secrets
     let router = router(secret);
 
-    Ok(router)
+    Ok(router.into())
 }
 ```
 
@@ -548,19 +546,18 @@ Now that we've changed the connection URL, our compiled assets in our Rust folde
 Now we can update our main function and router together so that the router will use a `SpaRouter` function provided by `axum_extra`, as well as use the static file path:
 
 ```rust
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn axum(
     #[shuttle_secrets::Secrets] secrets: SecretStore,
     #[shuttle_static_folder::StaticFolder] static_folder: PathBuf
 ) -> ShuttleAxum {
-
     // We use Secrets.toml to set the BEARER key, just like in a .env file and call it here
     let secret = secrets.get("BEARER").unwrap_or("Bear".to_string());
 
     // set up router with Secrets
     let router = router(secret, static_folder);
 
-    Ok(router)
+    Ok(router.into())
 }
 
 fn router(secret: String, static_folder: PathBuf) -> Router {

--- a/tutorials/websocket-chat-app-js.mdx
+++ b/tutorials/websocket-chat-app-js.mdx
@@ -248,12 +248,10 @@ Once the project has been created, you'll want to go into your `Cargo.toml` and 
 
 ```toml
 [package]
-name = "websocket-chat-react-rust" // The name here should be whatever you've decided to name your project
+name = "websocket-chat-react-rust" # The name here should be whatever you've decided to name your project
 version = "0.1.0"
 edition = "2021"
 publish = false
-
-[lib]
 
 [dependencies]
 axum = { version = "^0.6.2", features = ["ws"] }


### PR DESCRIPTION
This PR refactors the examples to binaries, so they will work with the changes we are implementing in the shuttle-next branch of the main repository. This PR also removes syncwrapper from the axum examples.

In addition to the above, we should fix all the imports when we settle on what they will be.
