### PR TITLE
feat: add protoc installation instructions

### DIFF
--- a/introduction/installation.mdx
+++ b/introduction/installation.mdx
@@ -13,7 +13,10 @@ which will automatically install the correct target for your system. to install 
 cargo binstall cargo-shuttle
 ```
 
-While it will be a bit slower, you can also install directly with cargo:
+While it will be a bit slower you can also install directly with cargo, but first you
+need to install `protoc`, check out our [protoc installation guide](../support/installing-protoc).
+
+Then, run:
 
 ```sh
 cargo install cargo-shuttle

--- a/introduction/quick-start.mdx
+++ b/introduction/quick-start.mdx
@@ -3,7 +3,8 @@ title: "Quick Start"
 ---
 
 We will assume that you have already installed shuttle. If you haven't, you should
-check out our [installation](./installation) section.
+check out our [installation](./installation) section. To run commands with the shuttle
+command line interface (`cargo shuttle`), you'll also need to [install protoc](../support/installing-protoc).
 
 To initialize your project, simply write:
 

--- a/mint.json
+++ b/mint.json
@@ -83,7 +83,11 @@
     },
     {
       "group": "Support",
-      "pages": ["support/faq", "support/troubleshooting"]
+      "pages": [
+        "support/faq",
+        "support/troubleshooting",
+        "support/installing-protoc"
+      ]
     },
     {
       "group": "Resources",

--- a/support/installing-protoc.mdx
+++ b/support/installing-protoc.mdx
@@ -1,0 +1,29 @@
+---
+title: "Installing Protoc"
+---
+
+Since `v0.12.0` `protoc` is a requirement to use and install `cargo-shuttle`. To install `protoc`, here
+are some instructions for Windows, Linux and Mac:
+
+### Windows
+
+On Windows the simplest way to install `protoc` is to first install [chocolatey](https://chocolatey.org/install), 
+and then simply run: `choco install protoc`.
+
+### Linux and Mac
+
+For Linux and Mac you can use this install script:
+```bash
+# replace <arch> with your architecture, for example for linux x86_64 replace <arch> with: linux-x86_64
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-<arch>.zip &&\
+    sudo unzip -o protoc-21.9-<arch>.zip -d /usr/local bin/protoc &&\
+    sudo unzip -o protoc-21.9-<arch>.zip -d /usr/local 'include/*' &&\
+    rm -f protoc-21.9-<arch>.zip
+```
+If you'd like to do this yourself without the above script, see instructions here: https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os
+
+On Mac you can also install protoc with `brew`: `brew install protobuf`.
+
+**Note:** *installing `protoc` on Linux with `apt-get install protobuf-compiler` will not be enough, 
+since it will install an old version of `protoc` (v3.12) but it needs to be at least v3.19. 
+Installing on mac using brew works.*

--- a/support/troubleshooting.mdx
+++ b/support/troubleshooting.mdx
@@ -5,15 +5,14 @@ title: "Troubleshooting"
 This section is aimed at collecting common issues users have to provide quick debug solutions.
 
 <AccordionGroup>
+  <Accordion title="I get an error about protoc not being installed, or protoc being the wrong version.">
+    Since `v0.12.0` `protoc` is a requirement to use and install `cargo-shuttle`. To install `protoc`, here
+    check out our installation guide: [installing protoc](./installing-protoc)
+  </Accordion>
   <Accordion title="I've updated shuttle and my project isn't working anymore.">
     If you've recently updated shuttle, in order to get your project back up, you need to run:
     **`cargo shuttle project rm`** followed by
     **`cargo shuttle project new`** and everything should be back in working order.
-  </Accordion>
-  <Accordion title="I can't deploy nor run locally, what should I do? (Windows)">
-    Some projects currently fail to deploy on Windows. The bug is related to&nbsp;[this Cargo meta-issue](https://github.com/rust-lang/cargo/issues/9770). Cargo is still trying to determine how to fix them properly in general.
-
-    As a temporary fix, you can try running **`cargo build`** before **`cargo shuttle deploy`** or **`cargo shuttle run`**.
   </Accordion>
   <Accordion title="I'm struggling to install shuttle on my M1/M2 Mac, what should I do?">
     There's a known bug with arm64 because of the openssl crates being built for x86, rather than arm64. In order to get around that issue, you can either run:


### PR DESCRIPTION
We can't link to an accordion in troubleshooting, so I made it a standalone page.