### PR TITLE
Add example of `shuttle logs --follow`

### DIFF
--- a/introduction/telemetry.mdx
+++ b/introduction/telemetry.mdx
@@ -63,3 +63,5 @@ And last but not least, if you'd like a live feed of your logs, run:
 ```bash
 cargo shuttle logs --follow
 ```
+
+[![asciicast](https://asciinema.org/a/kwwJB72isJlJNm7IF6zaNwIDA.svg)](https://asciinema.org/a/kwwJB72isJlJNm7IF6zaNwIDA)


### PR DESCRIPTION
This commit adds an https://asciinema.org recording of what happens when you view your shuttle logs.

This is a small change, but I wasn't exactly sure what shuttle logs by default (and I hadn't added any logging myself) so didn't really grok exactly what this would do. And you know what they say, a lossless terminal recording is worth 1000 comments.

This PR just embeds an image which the user can click to go through to asciinema to view the recording, but if `script` tags are allowed then this snippet:

```
<script async id="asciicast-kwwJB72isJlJNm7IF6zaNwIDA" src="https://asciinema.org/a/kwwJB72isJlJNm7IF6zaNwIDA.js"></script>
```

will actually embed the full viewer into the docs, which would be nice if possible.