### PR TITLE
docs: update local run discussion with inner dev loop

### DIFF
--- a/introduction/local-run.mdx
+++ b/introduction/local-run.mdx
@@ -15,7 +15,7 @@ cargo shuttle run
 ```
 
 ### Inner development loop
-The power of the inner development loop can be harnassed when developing locally with Shuttle! Leverage `cargo watch` like this:
+The power of the inner development loop can be harnessed when developing locally with Shuttle! Leverage `cargo watch` like this:
 ```bash
 cargo watch -x check -x clippy -x fmt -x test -x 'shuttle run'
 ```

--- a/introduction/local-run.mdx
+++ b/introduction/local-run.mdx
@@ -14,6 +14,21 @@ project directory, run:
 cargo shuttle run
 ```
 
+### Inner development loop
+The power of the inner development loop can be harnassed when developing locally with Shuttle! Leverage `cargo watch` like this:
+```bash
+cargo watch -x check -x clippy -x fmt -x test -x 'shuttle run'
+```
+This will:
+- start up cargo in watch mode (looks for changes to your files)
+- run cargo check
+- run cargo clippy
+- run cargo fmt
+- run any tests
+- run locally with shuttle
+
+The inner development loop provides a rapid cycle of feedback as you develop your app.
+
 ### Local runs with databases
 
 If your project relies on a database resource, it will default to starting a [docker](https://docs.docker.com/get-docker/) 


### PR DESCRIPTION
Good evening,

I updated the "Local Run" section within "Introduction" in the docs to describe that you can use the inner development loop (with cargo watch and flags) when developing locally with Shuttle.

This may not be a good fit, but I thought I'd suggest it and do a PR for consideration :)

(I was quite excited when I realized this could be done...)

~Jeff Mitchell