### PR TITLE
Add RDS permanence clarification

### DIFF
--- a/resources/shuttle-aws-rds.mdx
+++ b/resources/shuttle-aws-rds.mdx
@@ -7,6 +7,8 @@ This plugin provisions databases on AWS RDS using [Shuttle](https://www.shuttle.
 - MySql
 - MariaDB
 
+Shuttle makes sure that any data stored in your provisioned database is stored permanently and will persist if you redeploy your server  via `cargo shuttle deploy`, as well as if you restart your service via `cargo shuttle project restart`.
+
 ## Usage
 Each engine is behind a feature flag, and can be installed with the following commands and
 used with the following attribute paths:

--- a/resources/shuttle-aws-rds.mdx
+++ b/resources/shuttle-aws-rds.mdx
@@ -7,7 +7,7 @@ This plugin provisions databases on AWS RDS using [Shuttle](https://www.shuttle.
 - MySql
 - MariaDB
 
-Shuttle makes sure that any data stored in your provisioned database is stored permanently and will persist if you redeploy your server  via `cargo shuttle deploy`, as well as if you restart your service via `cargo shuttle project restart`.
+Shuttle makes sure that any data stored in your provisioned database is stored permanently and will persist if you redeploy your server via `cargo shuttle deploy`, as well as if you restart your service via `cargo shuttle project restart`.
 
 ## Usage
 Each engine is behind a feature flag, and can be installed with the following commands and


### PR DESCRIPTION
Another little (and optional) change. I wasn't too sure if shuttle would keep the data stored in a DB across deployments/restarts or if I would need to find something to keep the data permanently. I couldn't find anything that was super explicit about this, but 🌸Rain🌸 (rainofthestorm) on discord helped me out.

Very happy to not include this one-liner if it's mentioned elsewhere in the docs or if those in the know think it's a bit over the top.