### PR TITLE
docs: Fix "Databases with Rust" page minor error

### DIFF
--- a/tutorials/databases-with-rust.mdx
+++ b/tutorials/databases-with-rust.mdx
@@ -2,7 +2,7 @@
 title: "Working with Databases in Rust"
 ---
 
-In this guide we'll be looking at working with PostgresQL & MongoDB and how we can interface with them easily using Rust. By the end of this guide you'll have more of an idea of how to use both and when each one would be better for your use case.
+In this guide we'll be looking at working with PostgresQL & `shuttle-persist` (Shuttle's key-value data store) and how we can interface with them easily using Rust. By the end of this guide you'll have more of an idea of how to use both and when each one would be better for your use case.
 
 It will be assumed you already have a project initialised - if not, you can always initialise a new project with `cargo shuttle init`.
 


### PR DESCRIPTION
Fixes minor nitpick where it says MongoDB but should actually say `shuttle-persist`.