### PR TITLE
Fixed image URLs in tutorials/serverless-calendar-app

### DIFF
--- a/tutorials/serverless-calendar-app.mdx
+++ b/tutorials/serverless-calendar-app.mdx
@@ -298,7 +298,7 @@ Nice, it works!
 
 Opening it in the browser creates a new event in the calendar:
 
-![][/images/serverless-calendar-app-1.png]
+![][/images/serverless-calendar-app-1.avif]
 
 And for all the odd people who don't use a terminal to create a calendar event,
 let's also add a form to the website.
@@ -360,7 +360,7 @@ async fn calendar(Query(params): Query<HashMap<String, String>>) -> impl IntoRes
 After some more tweaking, we got ourselves a nice little form in all of its web
 1.0 glory.
 
-![Serverless Calendar app][/images/serverless-calendar-app-2.png]
+![Serverless Calendar app][/images/serverless-calendar-app-2.avif]
 
 And that's it! We now have a little web app that can create calendar events.
 Well, almost. We still need to deploy it.


### PR DESCRIPTION
Replaced incorrect .png URLs with .avif.

(To see the incorrect .png URLs, search for ".png" https://docs.shuttle.rs/tutorials/serverless-calendar-app, and compare to https://endler.dev/2022/zerocal.)

Thank you for shuttle.rs.