### PR TITLE
docs: Fix various minor typos

### DIFF
--- a/configuration/shuttle-service-name.mdx
+++ b/configuration/shuttle-service-name.mdx
@@ -27,7 +27,7 @@ If the `--name` option with a command is not used, the next method to name a pro
 name = <your-project-name>
 ```
 
-Where `<your-project-name>` is whatever you wish to name the project.  This method of naming supercedes any name set in `Cargo.toml`.
+Where `<your-project-name>` is whatever you wish to name the project.  This method of naming supersedes any name set in `Cargo.toml`.
 
 ## via Cargo.toml
 

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -569,7 +569,7 @@ use rocket::{
 use serde::{Deserialize, Serialize};
 
 // TODO: this has an extra trailing space to cause the test to fail
-// This is to demonstate shuttle will not deploy when a test fails.
+// This is to demonstrate shuttle will not deploy when a test fails.
 // FIX: remove the extra space character and try deploying again
 const BEARER: &str = "Bearer  ";
 const AUTHORIZATION: &str = "Authorization";

--- a/introduction/quick-start.mdx
+++ b/introduction/quick-start.mdx
@@ -30,7 +30,7 @@ And to deploy it:
 cargo shuttle deploy
 ```
 
-<Info> In case you haven't commited the changes to your repo, you'll have to add a `--allow-dirty` flag. </Info>
+<Info> In case you haven't committed the changes to your repo, you'll have to add a `--allow-dirty` flag. </Info>
 
 You can also run your project locally for development, check out our [local run](./local-run) section.
 

--- a/resources/overview.mdx
+++ b/resources/overview.mdx
@@ -27,7 +27,7 @@ The Shared Databases plugin will spin up a shared Postgres or MongoDB database i
 
 ### Secrets
 
-The Shuttle Secrets plugin provides a place to store environment variables which are sensitve and cannot be committed into version control.
+The Shuttle Secrets plugin provides a place to store environment variables which are sensitive and cannot be committed into version control.
 
 ### Static Folder
 

--- a/tutorials/databases-with-rust.mdx
+++ b/tutorials/databases-with-rust.mdx
@@ -28,7 +28,7 @@ created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 ``` 
 
-When we run our migrations, this folder will be the default that will be used - when we're ready to run our migrations, we can run `sqlx migrate run --database-url <database-url>`. We can also just run the migrate macro programatically after connecting to the database:
+When we run our migrations, this folder will be the default that will be used - when we're ready to run our migrations, we can run `sqlx migrate run --database-url <database-url>`. We can also just run the migrate macro programmatically after connecting to the database:
 
 ```rust
 sqlx::migrate!().run(&pool).await.expect("Migrations failed :(");

--- a/tutorials/rest-http-service-with-axum.mdx
+++ b/tutorials/rest-http-service-with-axum.mdx
@@ -199,7 +199,7 @@ Router::new()
 
 Cookies are essentially a way to store data on the user side. They have a variety of uses for web development; we can use them for tracking metrics for targeted advertising, we can use them for storing player score data and more. Cookies are also used for application authentication; however, it should be said that although this is a valid use case, **no user information like username or passwords should be stored through cookies - only session IDs that get validated against a database.**
 
-Cookies in Axum can be easily handled through use of axum-extra's [cookiejar](https://docs.rs/axum-extra/latest/axum_extra/extract/cookie/struct.CookieJar.html) types. There are three types, a private cookiejar (where it uses private signing), a signed cookiejar where all cookies are signed publically and then a regular cookiejar. You will need to enable the relevant flag to be able to use cookies, but you can enable the private cookiejar (for example) by running the following command:
+Cookies in Axum can be easily handled through use of axum-extra's [cookiejar](https://docs.rs/axum-extra/latest/axum_extra/extract/cookie/struct.CookieJar.html) types. There are three types, a private cookiejar (where it uses private signing), a signed cookiejar where all cookies are signed publicly and then a regular cookiejar. You will need to enable the relevant flag to be able to use cookies, but you can enable the private cookiejar (for example) by running the following command:
 
 ```bash
 cargo add axum-extra --features cookie-private


### PR DESCRIPTION
I stumbled upon a couple of typos when reading through the docs the other day, so I scanned the repo and found a few more. Nothing groundbreaking here!