### PR TITLE
fix: Macro syntax error

### DIFF
--- a/tutorials/rest-http-service-with-axum.mdx
+++ b/tutorials/rest-http-service-with-axum.mdx
@@ -118,7 +118,7 @@ async fn router() -> Router {
 State in Axum is a way to share scoped app-wide variables over your Router - this is great for us as we can store things like a database connection pool, a hashmap key-value store or an API key for an external service inside. Basic usage of a state struct might look like this:
 
 ```rust
-[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 struct MyAppState {
     db_connection: PgPool,
 }


### PR DESCRIPTION
Fixes a macro error (where there should be a hash there is none)