### PR TITLE
docs: fix typo in eu-west region number

### DIFF
--- a/support/faq.mdx
+++ b/support/faq.mdx
@@ -43,7 +43,7 @@ This section is aimed at collecting common questions users have to provide docum
     Certainly. Just create a `Shuttle.toml` file in the same directory where your `Cargo.toml` is and add `name = "your-project-name"`.
   </Accordion>
   <Accordion title="Where geographically are deployments hosted?">
-    Currently, all deployments are in the eu-west1 region (London).
+    Currently, all deployments are in the eu-west2 region (London).
   </Accordion>
   <Accordion title="Do we plan to support multiple regions?">
     We do plan to support multiple regions, but we can't give a precise ETA yet.


### PR DESCRIPTION
Redoing this PR because I accidentally deleted the first one I did.  Addresses open Issue #162.