### PR TITLE
improvement: add section discussing Metadata

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -59,9 +59,7 @@
         "getting-started/workspaces",
         {
           "group": "Custom Config",
-          "pages": [
-            "configuration/shuttle-service-name"
-          ]
+          "pages": ["configuration/shuttle-service-name"]
         }
       ]
     },
@@ -69,6 +67,7 @@
       "group": "Resources",
       "pages": [
         "resources/overview",
+        "resources/shuttle-metadata",
         {
           "group": "Databases",
           "pages": [
@@ -80,15 +79,11 @@
         },
         {
           "group": "Environment Variables",
-          "pages": [
-            "resources/shuttle-secrets"
-          ]
+          "pages": ["resources/shuttle-secrets"]
         },
         {
           "group": "Static Files",
-          "pages": [
-            "resources/shuttle-static-folder"
-          ]
+          "pages": ["resources/shuttle-static-folder"]
         }
       ]
     },
@@ -113,10 +108,7 @@
         },
         {
           "group": "Rocket",
-          "pages": [
-            "examples/rocket",
-            "examples/rocket-jwt-authentication"
-          ]
+          "pages": ["examples/rocket", "examples/rocket-jwt-authentication"]
         },
         {
           "group": "Serenity",
@@ -132,9 +124,7 @@
     },
     {
       "group": "Migration",
-      "pages": [
-        "migration/migrating-to-shuttle"
-      ]
+      "pages": ["migration/migrating-to-shuttle"]
     },
     {
       "group": "How To",
@@ -151,24 +141,15 @@
     },
     {
       "group": "Fullstack Templates",
-      "pages": [
-        "fullstack/rust-next",
-        "fullstack/saas-template"
-      ]
+      "pages": ["fullstack/rust-next", "fullstack/saas-template"]
     },
     {
       "group": "Shuttle Next (Framework) 🧪",
-      "pages": [
-        "shuttle-next/overview",
-        "shuttle-next/getting-started"
-      ]
+      "pages": ["shuttle-next/overview", "shuttle-next/getting-started"]
     },
     {
       "group": "Support",
-      "pages": [
-        "support/faq",
-        "support/troubleshooting"
-      ]
+      "pages": ["support/faq", "support/troubleshooting"]
     },
     {
       "group": "Community",

--- a/resources/shuttle-metadata.mdx
+++ b/resources/shuttle-metadata.mdx
@@ -6,7 +6,7 @@ The metadata plugin allows applications to obtain certain information about thei
 
 ## Usage
 
-To use the metadata plugin, add `shuttle-metadata` to the dependencies for your service by manually editing the project's `cargo.toml` file or by invoking `cargo add shuttle-metadata` from the command line.
+To use the metadata plugin, add `shuttle-metadata` to the dependencies for your service by manually editing the project's `Cargo.toml` file or by invoking `cargo add shuttle-metadata` from the command line.
 
 Once the metadata plugin dependency is available to your project, use the resource by annotating your main function with the `shuttle_metadata::ShuttleMetadata` attribute. Doing this enables return of a MetaData struct which will contain information such as the Shuttle service name.
 
@@ -30,7 +30,7 @@ async fn axum(
 
 This example has one route which returns the Shuttle service name in JSON format:
 
-```JSON
+```text
 Metadata { service_name: "metadata-example" }
 ```
 

--- a/resources/shuttle-metadata.mdx
+++ b/resources/shuttle-metadata.mdx
@@ -1,0 +1,37 @@
+---
+title: Metadata
+---
+
+The metadata plugin allows applications to obtain certain information about their runtime environment.
+
+## Usage
+
+To use the metadata plugin, add `shuttle-metadata` to the dependencies for your service by manually editing the project's `cargo.toml` file or by invoking `cargo add shuttle-metadata` from the command line.
+
+Once the metadata plugin dependency is available to your project, use the resource by annotating your main function with the `shuttle_metadata::ShuttleMetadata` attribute. Doing this enables return of a MetaData struct which will contain information such as the Shuttle service name.
+
+## Example
+
+This snippet shows an Axum main function, annotated with the `shuttle_metadata::ShuttleMetadata` attribute.
+
+```rust main.rs
+use axum::{routing::get, Router};
+use shuttle_metadata::Metadata;
+
+#[shuttle_runtime::main]
+async fn axum(
+    #[shuttle_metadata::ShuttleMetadata] metadata: Metadata,
+) -> shuttle_axum::ShuttleAxum {
+    let router = Router::new().route("/", get(format!("{:?}", metadata)));
+
+    Ok(router.into())
+}
+```
+
+This example has one route which returns the Shuttle service name in JSON format:
+
+```JSON
+Metadata { service_name: "metadata-example" }
+```
+
+The full example can also be found on [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/axum/metadata)


### PR DESCRIPTION
I added a new section under resources to cover metadata.  As @oddgrd suggested, I borrowed a lot from the shuttle-metadata crate docs. Not sure if the spot I chose was the best (under Resources) but I though this was a start.

This PR is related to Issue #168.