### PR TITLE
chore: update docs and remove libsql-client note

### DIFF
--- a/resources/shuttle-turso.mdx
+++ b/resources/shuttle-turso.mdx
@@ -5,25 +5,25 @@ title: "Shuttle Turso"
 This plugin allows services to connect to a [Turso](https://turso.tech) database. Turso is an edge-hosted distributed database based on libSQL, a SQLite fork.
 
 ## Usage
+
 **IMPORTANT:** Currently Shuttle isn't able to provision a Turso database for you (yet). This means you will have to create an account on their [website](https://turso.tech/) and follow the few steps required to create a database and create a token to access it.
 
 Add `shuttle-turso` and `libsql-client` to the dependencies for your service by running `cargo add shuttle-turso libsql-client`. This resource will be provided by adding the `shuttle_turso::Turso` attribute to your Shuttle main decorated function.
-
-<Note>Internally, `shuttle_turso::Turso` pins version 0.30.1 of `libsql-client`. If you add `libsql-client` either with `cargo add` or manually, it will be necessary to edit your Cargo.toml file afterwards to downgrade to version 0.30.1.</Note>
 
 It returns a `libsql_client::Client`. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
 
 If you want to connect to a remote database when running locally, you can specify the `local_addr` parameter. In that case, the token will be read from your `Secrets.dev.toml` file.
 
-
 ### Parameters
-|  Parameter |  Type  | Default |                                                                    Description                                                                   |
-|------------|--------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+
+| Parameter  | Type   | Default | Description                                                                                                                                      |
+| ---------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | addr       | str    | `""`    | URL of the database to connect to. If `libsql://`` is missing at the beginning, it will be automatically added.                                  |
 | token      | str    | `""`    | The value of the token to authenticate against the Turso database. You can use string interpolation to read a secret from your Secret.toml file. |
 | local_addr | Option | `None`  | The URL to use when running your service locally. If not provided, this will default to a local file named `<service-name>.db`                   |
 
 ### Example
+
 In the case of an Axum server, your main function will look like this:
 
 ```rust
@@ -33,11 +33,11 @@ use shuttle_axum::ShuttleAxum;
 #[shuttle_runtime::main]
 async fn app(
 #[shuttle_turso::Turso(
-    addr="libsql://my-turso-db-name.turso.io", 
+    addr="libsql://my-turso-db-name.turso.io",
 	token="{secrets.DB_TURSO_TOKEN}")] client: Client,
 // use secrets if you are not hardcoding your token/addr
 #[shuttle_secrets::Secrets] secrets: SecretStore
-) -> ShuttleAxum { 
+) -> ShuttleAxum {
 // ... some code
 }
 ```


### PR DESCRIPTION
I've updated the shuttle-turso docs section to remove the note about needing to downgrade to version 0.30.1 after installing the libsql-client.