### PR TITLE
improvement: update for rocket rc.4

### DIFF
--- a/examples/rocket-jwt-authentication.mdx
+++ b/examples/rocket-jwt-authentication.mdx
@@ -36,7 +36,7 @@ edition = "2021"
 chrono = "0.4.23"
 jsonwebtoken = { version = "8.1.1", default-features = false }
 lazy_static = "1.4.0"
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
+rocket = { version = "0.5.0-rc.4", features = ["json"] }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-rocket = "0.32.0"
 shuttle-runtime = "0.32.0"
@@ -177,9 +177,9 @@ impl<'r> FromRequest<'r> for Claims {
 
     async fn from_request(request: &'r rocket::Request<'_>) -> Outcome<Self, Self::Error> {
         match request.headers().get_one(AUTHORIZATION) {
-            None => Outcome::Failure((Status::Forbidden, AuthenticationError::Missing)),
+            None => Outcome::Error((Status::Forbidden, AuthenticationError::Missing)),
             Some(value) => match Claims::from_authorization(value) {
-                Err(e) => Outcome::Failure((Status::Forbidden, e)),
+                Err(e) => Outcome::Error((Status::Forbidden, e)),
                 Ok(claims) => Outcome::Success(claims),
             },
         }

--- a/examples/rocket-postgres.mdx
+++ b/examples/rocket-postgres.mdx
@@ -37,7 +37,7 @@ async fn retrieve(id: i32, state: &State<MyState>) -> Result<Json<Todo>, BadRequ
         .bind(id)
         .fetch_one(&state.pool)
         .await
-        .map_err(|e| BadRequest(Some(e.to_string())))?;
+        .map_err(|e| BadRequest(e.to_string()))?;
 
     Ok(Json(todo))
 }
@@ -51,7 +51,7 @@ async fn add(
         .bind(&data.note)
         .fetch_one(&state.pool)
         .await
-        .map_err(|e| BadRequest(Some(e.to_string())))?;
+        .map_err(|e| BadRequest(e.to_string()))?;
 
     Ok(Json(todo))
 }
@@ -102,11 +102,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
+rocket = { version = "0.5.0-rc.4", features = ["json"] }
 serde = "1.0.148"
-shuttle-shared-db = { version = "0.27.0", features = ["postgres"] }
-shuttle-rocket = "0.27.0"
-shuttle-runtime = "0.27.0"
+shuttle-shared-db = { version = "0.32.0", features = ["postgres"] }
+shuttle-rocket = "0.32.0"
+shuttle-runtime = "0.32.0"
 sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1.26.0"
 ```

--- a/examples/rocket-static-files.mdx
+++ b/examples/rocket-static-files.mdx
@@ -75,9 +75,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rocket = "0.5.0-rc.2"
-shuttle-rocket = "0.27.0"
-shuttle-runtime = "0.27.0"
+rocket = "0.5.0-rc.4"
+shuttle-rocket = "0.32.0"
+shuttle-runtime = "0.32.0"
 tokio = "1.26.0"
 ```
 

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -42,7 +42,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rocket = "0.5.0-rc.2"
+rocket = "0.5.0-rc.4"
 shuttle-rocket = "0.32.0"
 shuttle-runtime = "0.32.0"
 tokio = "1.26.0"


### PR DESCRIPTION
I've updated the Rocket related documentation to match up with the changes to shuttle-examples, to reflect resolution to the changes related to rocket 0.5.0-rc.4. I also took the opportunity to update the shuttle version in the examples, if I saw it was out of date.