### PR TITLE
improvement: update url-shortener article

### DIFF
--- a/tutorials/url-shortener.mdx
+++ b/tutorials/url-shortener.mdx
@@ -17,7 +17,7 @@ I don't want to have to deal with Terraform and Kubernetes at midnight. I want
 to write scalable code and just get it deployed. I want my dependencies
 generated and managed for me. I want to be able to sleep at night.
 
-It's 2022. **Surely** we can do better. As I stared blankly at my white ceiling,
+It's 2023. **Surely** we can do better. As I stared blankly at my white ceiling,
 I decided to see if it was possible.
 
 I suddenly sat up in bed. Can I create a useful app, with some sort of database
@@ -128,7 +128,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rocket = "0.5.0-rc.2"
+rocket = "0.5.0-rc.4"
 shuttle-rocket = { version = "0.32.0" }
 shuttle-runtime = { version = "0.32.0" }
 tokio = { version = "1.26.0" }
@@ -147,12 +147,13 @@ $ cargo shuttle deploy
    Archiving src/main.rs
    Compiling tracing-attributes v0.1.20
    Compiling tokio-util v0.6.9
-   Compiling multer v2.0.2
-   Compiling hyper v0.14.18
-   Compiling rocket_http v0.5.0-rc.1
-   Compiling rocket_codegen v0.5.0-rc.1
-   Compiling rocket v0.5.0-rc.1
-   Compiling shuttle-service v0.15.0
+   Compiling multer v2.1.0
+   Compiling hyper v0.14.27
+   Compiling rocket_http v0.5.0-rc.4
+   Compiling rocket_codegen v0.5.0-rc.4
+   Compiling rocket v0.5.0-rc.4
+   Compiling shuttle-rocket v0.32.0
+   Compiling shuttle-runtime v0.32.0
    Compiling url-shortener v0.1.0 (/opt/shuttle/crates/url-shortener)
     Finished dev [unoptimized + debuginfo] target(s) in 1m 01s
 


### PR DESCRIPTION
I've updated the url-shortener article in the "How-to" section to reflect the latest rc4 version of Rocket. Also took the liberty of updating the year to 2023...makes the article seem a little more fresh :)

I'll update the blog version this evening.

~Jeff