### PR TITLE
chore: v0.35.1

### DIFF
--- a/configuration/shuttle-versions.mdx
+++ b/configuration/shuttle-versions.mdx
@@ -20,7 +20,7 @@ Combining all of the above, these are the recommended steps for upgrading a Shut
 
 2. Update your project's `shuttle-...` dependencies in `Cargo.toml`:
    ```toml Cargo.toml
-   shuttle-runtime = "0.35.0"
+   shuttle-runtime = "0.36.0"
    # etc
    ```
 

--- a/examples/actix-postgres.mdx
+++ b/examples/actix-postgres.mdx
@@ -117,10 +117,10 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.3.1"
-shuttle-actix-web = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-actix-web = "0.36.0"
+shuttle-runtime = "0.36.0"
 serde = "1.0.148"
-shuttle-shared-db = { version = "0.35.0", features = ["postgres"] }
+shuttle-shared-db = { version = "0.36.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1.26.0"
 ```

--- a/examples/actix-websocket-actorless.mdx
+++ b/examples/actix-websocket-actorless.mdx
@@ -407,8 +407,8 @@ futures = "0.3"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-actix-web = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-actix-web = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 tracing = "0.1"
 ```

--- a/examples/actix.mdx
+++ b/examples/actix.mdx
@@ -45,8 +45,8 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.3.1"
-shuttle-actix-web = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-actix-web = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 </CodeGroup>

--- a/examples/axum-static-files.mdx
+++ b/examples/axum-static-files.mdx
@@ -59,8 +59,8 @@ publish = false
 
 [dependencies]
 axum = "0.6.18"
-shuttle-axum = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-axum = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.28.2"
 tower-http = { version = "0.4.0", features = ["fs"] }
 ```

--- a/examples/axum-websockets.mdx
+++ b/examples/axum-websockets.mdx
@@ -277,8 +277,8 @@ hyper = { version = "0.14.26", features = ["client", "http2"] }
 hyper-tls = "0.5.0"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
-shuttle-axum = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-axum = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.28.2"
 tower-http = { version = "0.4.0", features = ["fs"] }
 ```

--- a/examples/axum.mdx
+++ b/examples/axum.mdx
@@ -42,8 +42,8 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.18"
-shuttle-axum = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-axum = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.28.2"
 ```
 </CodeGroup>

--- a/examples/poise.mdx
+++ b/examples/poise.mdx
@@ -71,9 +71,9 @@ publish = false
 [dependencies]
 anyhow = "1.0.71"
 poise = "0.5.5"
-shuttle-poise = "0.35.0"
-shuttle-runtime = "0.35.0"
-shuttle-secrets = "0.35.0"
+shuttle-poise = "0.36.0"
+shuttle-runtime = "0.36.0"
+shuttle-secrets = "0.36.0"
 tracing = "0.1.37"
 tokio = "1.28.2"
 ```

--- a/examples/rocket-jwt-authentication.mdx
+++ b/examples/rocket-jwt-authentication.mdx
@@ -38,8 +38,8 @@ jsonwebtoken = { version = "8.1.1", default-features = false }
 lazy_static = "1.4.0"
 rocket = { version = "0.5.0", features = ["json"] }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-rocket = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 Your `main.rs` should look like this:

--- a/examples/rocket-postgres.mdx
+++ b/examples/rocket-postgres.mdx
@@ -104,9 +104,9 @@ edition = "2021"
 [dependencies]
 rocket = { version = "0.5.0", features = ["json"] }
 serde = "1.0.148"
-shuttle-shared-db = { version = "0.35.0", features = ["postgres"] }
-shuttle-rocket = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-shared-db = { version = "0.36.0", features = ["postgres"] }
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1.26.0"
 ```

--- a/examples/rocket-static-files.mdx
+++ b/examples/rocket-static-files.mdx
@@ -76,8 +76,8 @@ publish = false
 
 [dependencies]
 rocket = "0.5.0"
-shuttle-rocket = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 

--- a/examples/rocket.mdx
+++ b/examples/rocket.mdx
@@ -43,8 +43,8 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0"
-shuttle-rocket = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 </CodeGroup>

--- a/examples/serenity-todo.mdx
+++ b/examples/serenity-todo.mdx
@@ -268,10 +268,10 @@ edition = "2021"
 anyhow = "1.0.66"
 serde = "1.0.148"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.35.0"
-shuttle-serenity = "0.35.0"
-shuttle-runtime = "0.35.0"
-shuttle-shared-db = { version = "0.35.0", features = ["postgres"] }
+shuttle-secrets = "0.36.0"
+shuttle-serenity = "0.36.0"
+shuttle-runtime = "0.36.0"
+shuttle-shared-db = { version = "0.36.0", features = ["postgres"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1.26.0"
 tracing = "0.1.37"

--- a/examples/serenity.mdx
+++ b/examples/serenity.mdx
@@ -90,10 +90,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-shuttle-serenity = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-serenity = "0.36.0"
+shuttle-runtime = "0.36.0"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
-shuttle-secrets = "0.35.0"
+shuttle-secrets = "0.36.0"
 tokio = "1.26.0"
 tracing = "0.1.37"
 ```

--- a/examples/shuttle-next.mdx
+++ b/examples/shuttle-next.mdx
@@ -42,7 +42,7 @@ edition = "2021"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-shuttle-next = "0.35.0"
+shuttle-next = "0.36.0"
 ```
 
 Using the `shuttle-next::app!` macro, we can create HTTP API endpoints, setting the

--- a/shuttle-next/getting-started.mdx
+++ b/shuttle-next/getting-started.mdx
@@ -22,7 +22,7 @@ edition = "2021"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-shuttle-next = "0.35.0"
+shuttle-next = "0.36.0"
 ```
 
 Using the `shuttle-next::app!` macro, we can create HTTP API endpoints, setting the

--- a/tutorials/custom-service.mdx
+++ b/tutorials/custom-service.mdx
@@ -47,8 +47,8 @@ axum = "0.6.4"
 hyper = "0.14.24"
 poise = "0.5.2"
 serde = "1.0"
-shuttle-runtime = "0.35.0"
-shuttle-secrets = "0.35.0"
+shuttle-runtime = "0.36.0"
+shuttle-secrets = "0.36.0"
 tokio = "1.26.0"
 ```
 

--- a/tutorials/url-shortener.mdx
+++ b/tutorials/url-shortener.mdx
@@ -129,8 +129,8 @@ edition = "2021"
 
 [dependencies]
 rocket = "0.5.0"
-shuttle-rocket = "0.35.0"
-shuttle-runtime = "0.35.0"
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 
@@ -152,8 +152,8 @@ $ cargo shuttle deploy
    Compiling rocket_http v0.5.0
    Compiling rocket_codegen v0.5.0
    Compiling rocket v0.5.0
-   Compiling shuttle-rocket v0.35.0
-   Compiling shuttle-runtime v0.35.0
+   Compiling shuttle-rocket v0.36.0
+   Compiling shuttle-runtime v0.36.0
    Compiling url-shortener v0.1.0 (/opt/shuttle/crates/url-shortener)
     Finished dev [unoptimized + debuginfo] target(s) in 1m 01s
 

--- a/tutorials/websocket-chat-app-js.mdx
+++ b/tutorials/websocket-chat-app-js.mdx
@@ -257,10 +257,10 @@ hyper = { version = "0.14", features = ["client", "http2"] }
 hyper-tls = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-axum = { version = "0.35.0" }
-shuttle-runtime = { version = "0.35.0" }
-shuttle-secrets = "0.35.0"
-shuttle-static-folder = "0.35.0"
+shuttle-axum = { version = "0.36.0" }
+shuttle-runtime = { version = "0.36.0" }
+shuttle-secrets = "0.36.0"
+shuttle-static-folder = "0.36.0"
 sync_wrapper = "0.1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.3.5", features = ["fs", "auth"]}


### PR DESCRIPTION
Please make an abstraction from the branch name, it was created for the 0.36.0 version but @jonaro00 had a good suggestion that this release is more like a 0.35.1 (and one of the reasons I think this makes sense is because users shouldn't upgrade their projects). 