### PR TITLE
Fixed shell completion documentation

### DIFF
--- a/getting-started/shuttle-commands.mdx
+++ b/getting-started/shuttle-commands.mdx
@@ -91,6 +91,6 @@ All project-related commands can use:
 
 ### Shell completions
 
-Use `cargo shuttle generate -s <shell>` with one of: bash, elvish, fish, powershell, zsh.
+Use `cargo shuttle generate shell <shell>` with one of: bash, elvish, fish, powershell, zsh.
 
-Example configuration for Zsh on Linux: add `eval "$(cargo shuttle generate -s zsh)"` to `~/.zshrc`.
+Example configuration for Zsh on Linux: add `eval "$(cargo shuttle generate shell zsh)"` to `~/.zshrc`.


### PR DESCRIPTION
The cargo-shuttle cli does not align with what the documentation says.  This fixes that.