### PR TITLE
Add windows install script instructions

### DIFF
--- a/getting-started/installation.mdx
+++ b/getting-started/installation.mdx
@@ -8,14 +8,19 @@ The `cargo-shuttle` CLI can be installed with a pre-built binary, from source wi
 
 ### Install script
 
-The install script, available for Linux and macOS, finds the optimal alternative below for installing the latest version on your OS and distro.
-Run it with:
+The install script finds the optimal alternative below for installing the latest version on your OS, architecture and distro.
+
+Run it on Linux and macOS with:
 
 ```sh
 curl -sSfL https://www.shuttle.rs/install | bash
 ```
 
-On Windows, use one of the methods below.
+Or on Windows with:
+
+```powershell
+iwr "https://www.shuttle.rs/install-win" | iex
+```
 
 ### Pre-built binary
 


### PR DESCRIPTION
Updates https://docs.shuttle.rs/getting-started/installation to add Windows install script instructions.

Depends on shuttle-hq/shuttle#1503 and shuttle-hq/www#220