### PR TITLE
docs: add note about Docker "os error 2" issues

### DIFF
--- a/getting-started/local-run.mdx
+++ b/getting-started/local-run.mdx
@@ -30,6 +30,8 @@ async fn tide(
 ) -> ShuttleTide<MyState> { ... }
 ```
 
+<Note>**IMPORTANT:** If Docker isn't started, you may receive an "os error 2" error. This is typically related to your Docker installation. If you're using Docker via the CLI, you can use any Docker command to start it up. If you're using Docker Desktop, you will need to start Docker Desktop.</Note>
+
 ### Expose your application to your local network
 
 If you'd like to expose your application to you local network, for example if you're serving a static


### PR DESCRIPTION
Ref Discord help thread: https://discord.com/channels/803236282088161321/1230716219712344085

Local run documentation does not appear to be synced up with `shared-db` documentation with regards to ensuring that Docker is running.