### PR TITLE
docs: fix macro annotation typo

### DIFF
--- a/resources/shuttle-shared-db.mdx
+++ b/resources/shuttle-shared-db.mdx
@@ -37,7 +37,7 @@ Depending on which type declaration is used as the output type in the macro, you
 | MongoDB  | | `String` | The connection string including username and password |
 | MongoDB  | | `mongodb::Database` | A client pool connected to the database |
 
-Lastly, add a macro annotaion to the Shuttle main function. Here are examples for Postgres:
+Lastly, add a macro annotation to the Shuttle main function. Here are examples for Postgres:
 
 ```rust
 // Use the connection string


### PR DESCRIPTION
Correct a typo error in the word annotation