### PR TITLE
Correct parameter name.

### DIFF
--- a/resources/shuttle-qdrant.mdx
+++ b/resources/shuttle-qdrant.mdx
@@ -28,7 +28,7 @@ If you want to connect to a remote database when running locally, you can specif
 | ---------- | ------ | --------- | ----------- |
 | cloud_url  | &str   | In deployment | URL of the database to connect to. NOTE: It should use the gRPC port. |
 | api_key    | &str   | No | Required if the database requires an API key. |
-| local_addr | &str   | No | If specified, connect to this URL on local runs instead of using a Docker container. |
+| local_url  | &str   | No | If specified, connect to this URL on local runs instead of using a Docker container. |
 
 <Warning>Make sure the `cloud_url` parameter is specifying the gRPC port of the database. This is typically done by adding `:6334` at the end.</Warning>
 


### PR DESCRIPTION
Incorrect `local_addr` is replaced with the correct `local_url`.

See the [definition](https://github.com/shuttle-hq/shuttle/blob/05372f0965d02b3ef4d3718ffe1328c027a78b19/resources/qdrant/src/lib.rs#L12-L19) of `shuttle_qdrant::Qdrant`.

@joshua-mo-143
