### PR TITLE
docs: local-run.mdx still suggests running shuttle as cargo command instead of shell command

### DIFF
--- a/docs/local-run.mdx
+++ b/docs/local-run.mdx
@@ -63,9 +63,9 @@ To live reload your Shuttle app when you save a file, you can use [cargo-watch](
 
 ```bash
 # This will e(x)ecute `shuttle run` when you save a file.
-cargo watch -x 'shuttle run'
+cargo watch -s 'shuttle run'
 # This will also (q)uietly (c)lear the console between runs.
-cargo watch -qcx 'shuttle run'
+cargo watch -qcs 'shuttle run'
 
 # There are many other helpful options, see `cargo watch --help`
 ```

--- a/docs/local-run.mdx
+++ b/docs/local-run.mdx
@@ -62,7 +62,7 @@ Here are some small tips and tricks to boost your productivity when developing l
 To live reload your Shuttle app when you save a file, you can use [cargo-watch](https://github.com/watchexec/cargo-watch):
 
 ```bash
-# This will e(x)ecute `shuttle run` when you save a file.
+# This will execute `shuttle run` when you save a file.
 cargo watch -s 'shuttle run'
 # This will also (q)uietly (c)lear the console between runs.
 cargo watch -qcs 'shuttle run'


### PR DESCRIPTION
Local run docs still use `cargo watch -x 'shuttle run'`, which translates to `cargo shuttle run`; instead of using `cargo watch -s 'shuttle run'`, which translates to `shuttle run`.

This is just a quick fix to the docs.

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/c0cd98b4-eb7b-45d9-8a1a-53977f5e7f4f">
