### PR TITLE
fix: blog redirect link, async-trait

### DIFF
--- a/migrations/frameworks/custom-service.mdx
+++ b/migrations/frameworks/custom-service.mdx
@@ -14,6 +14,7 @@ To get started, you can use the following code below:
 ```rust data.rs
 pub struct DataStruct;
 
+#[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for DataStruct {
   async fn bind(
     mut self,
@@ -72,6 +73,7 @@ async fn loop() {
   }
 }
 
+#[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for DataStruct {
   async fn bind(
     mut self,

--- a/mint.json
+++ b/mint.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "Blog",
-      "url": "https://www.shuttle.dev/blog/"
+      "url": "https://www.shuttle.dev/blog/tags/all"
     }
   ],
   "navigation": [


### PR DESCRIPTION
Fixes the blog redirect link to not be a permanent SEO fix and an async-trait implementation on the Custom Service page.